### PR TITLE
fix: name of property typedoc plugins are specified in

### DIFF
--- a/src/plugins/typedoc/index.ts
+++ b/src/plugins/typedoc/index.ts
@@ -22,7 +22,7 @@ export const CONFIG_FILE_PATTERNS = [
 
 const findPluginDependencies: GenericPluginCallback = async configFilePath => {
   const config: PluginConfig = await _load(configFilePath);
-  return config?.plugins ?? [];
+  return config?.plugin ?? [];
 };
 
 export const findDependencies = timerify(findPluginDependencies);

--- a/src/plugins/typedoc/types.ts
+++ b/src/plugins/typedoc/types.ts
@@ -1,3 +1,3 @@
 export type PluginConfig = {
-  plugins?: string[];
+  plugin?: string[];
 };

--- a/test/fixtures/plugins/typedoc/typedoc.json
+++ b/test/fixtures/plugins/typedoc/typedoc.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["@appium/typedoc-plugin-appium", "typedoc-plugin-expand-object-like-types"]
+  "plugin": ["@appium/typedoc-plugin-appium", "typedoc-plugin-expand-object-like-types"]
 }


### PR DESCRIPTION
fix #64 
re https://github.com/webpro/knip/commit/73c3c5f5f706f4c8c1f24a585801674092f0a4eb#r102767065