### PR TITLE
fix: parse rc configs with no extension as either yaml or json

### DIFF
--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -1,6 +1,7 @@
 import { statSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import yaml from 'js-yaml';
 import stripJsonComments from 'strip-json-comments';
 import { LoaderError } from './errors.js';
 
@@ -18,6 +19,15 @@ export const loadJSON = async (filePath: string) => {
   try {
     const contents = await readFile(filePath);
     return JSON.parse(stripJsonComments(contents.toString()));
+  } catch (error) {
+    throw new LoaderError(`Error loading ${filePath}`, { cause: error });
+  }
+};
+
+export const loadYAML = async (filePath: string) => {
+  try {
+    const contents = await readFile(filePath);
+    return yaml.load(contents.toString());
   } catch (error) {
     throw new LoaderError(`Error loading ${filePath}`, { cause: error });
   }

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -15,20 +15,29 @@ export const findFile = (workingDir: string, fileName: string) => {
   return isFile(filePath) ? filePath : undefined;
 };
 
-export const loadJSON = async (filePath: string) => {
+export const loadFile = async (filePath: string) => {
   try {
     const contents = await readFile(filePath);
-    return JSON.parse(stripJsonComments(contents.toString()));
+    return contents.toString();
   } catch (error) {
     throw new LoaderError(`Error loading ${filePath}`, { cause: error });
   }
 };
 
+export const loadJSON = async (filePath: string) => {
+  const contents = await loadFile(filePath);
+  return parseJSON(contents);
+};
+
 export const loadYAML = async (filePath: string) => {
-  try {
-    const contents = await readFile(filePath);
-    return yaml.load(contents.toString());
-  } catch (error) {
-    throw new LoaderError(`Error loading ${filePath}`, { cause: error });
-  }
+  const contents = await loadFile(filePath);
+  return parseYAML(contents);
+};
+
+export const parseJSON = async (contents: string) => {
+  return JSON.parse(stripJsonComments(contents));
+};
+
+export const parseYAML = async (contents: string) => {
+  return yaml.load(contents);
 };

--- a/src/util/loader.ts
+++ b/src/util/loader.ts
@@ -4,19 +4,15 @@ import { pathToFileURL } from 'node:url';
 import { load as esmLoad } from '@esbuild-kit/esm-loader';
 import { require } from '../util/require.js';
 import { LoaderError } from './errors.js';
-import { loadJSON, loadYAML } from './fs.js';
+import { loadJSON, loadYAML, loadFile, parseJSON, parseYAML } from './fs.js';
 import { timerify } from './performance.js';
 
 const load = async (filePath: string) => {
   try {
     const ext = path.extname(filePath);
     if (/rc$/.test(filePath)) {
-      try {
-        // Note: `await` is needed for the try-catch to work.
-        return await loadYAML(filePath);
-      } catch {
-        return loadJSON(filePath);
-      }
+      const contents = await loadFile(filePath);
+      return parseYAML(contents).catch(() => parseJSON(contents));
     }
 
     if (ext === '.json' || ext === '.jsonc') {

--- a/src/util/loader.ts
+++ b/src/util/loader.ts
@@ -1,23 +1,30 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 // eslint-disable-next-line import/order -- Modules in @types are handled differently
 import { load as esmLoad } from '@esbuild-kit/esm-loader';
-import yaml from 'js-yaml';
 import { require } from '../util/require.js';
 import { LoaderError } from './errors.js';
-import { loadJSON } from './fs.js';
+import { loadJSON, loadYAML } from './fs.js';
 import { timerify } from './performance.js';
 
 const load = async (filePath: string) => {
   try {
     const ext = path.extname(filePath);
-    if (ext === '.json' || ext === '.jsonc' || /rc$/.test(filePath)) {
+    if (/rc$/.test(filePath)) {
+      try {
+        // Note: `await` is needed for the try-catch to work.
+        return await loadYAML(filePath);
+      } catch {
+        return loadJSON(filePath);
+      }
+    }
+
+    if (ext === '.json' || ext === '.jsonc') {
       return loadJSON(filePath);
     }
 
     if (ext === '.yaml' || ext === '.yml') {
-      return yaml.load((await fs.readFile(filePath)).toString());
+      return loadYAML(filePath);
     }
 
     if (ext === '.mjs') {


### PR DESCRIPTION
rc files can often be written in either yaml or json so knip so try loading them as both.

As yaml is a super type of json. Any valid json can be parsed with the yaml parser - so it's more performant to try this one first. jsonc isn't valid yaml though so we still need to try the json parser if the yaml one fails.