### PR TITLE
fix: check nested eslint config files

### DIFF
--- a/src/plugins/eslint/README.md
+++ b/src/plugins/eslint/README.md
@@ -12,7 +12,12 @@ or `devDependencies`:
 ```json
 {
   "eslint": {
-    "config": [".eslintrc", ".eslintrc.{js,json,cjs}", ".eslintrc.{yml,yaml}", "package.json"],
+    "config": [
+      "**/.eslintrc",
+      "**/.eslintrc.{js,json,cjs}",
+      "**/.eslintrc.{yml,yaml}",
+      "package.json"
+    ],
     "entry": ["eslint.config.js"]
   }
 }

--- a/src/plugins/eslint/index.ts
+++ b/src/plugins/eslint/index.ts
@@ -11,7 +11,12 @@ export const ENABLERS = ['eslint'];
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
 // Current: https://eslint.org/docs/latest/user-guide/configuring/configuration-files
-export const CONFIG_FILE_PATTERNS = ['.eslintrc', '.eslintrc.{js,json,cjs}', '.eslintrc.{yml,yaml}', 'package.json'];
+export const CONFIG_FILE_PATTERNS = [
+  '**/.eslintrc',
+  '**/.eslintrc.{js,json,cjs}',
+  '**/.eslintrc.{yml,yaml}',
+  'package.json',
+];
 
 // New: https://eslint.org/docs/latest/user-guide/configuring/configuration-files-new
 // We can handle eslint.config.js just like other source code (as dependencies are imported)


### PR DESCRIPTION
eslint allows for multiple config files to exists within different directories of a project.