### PR TITLE
fix: include TEST_FILE_PATTERNS with empty entry

### DIFF
--- a/src/workspace-worker.ts
+++ b/src/workspace-worker.ts
@@ -130,8 +130,7 @@ export default class WorkspaceWorker {
 
   getEntryFilePatterns() {
     const { entry } = this.config;
-    if (entry.length === 0) return [];
-    return [entry, TEST_FILE_PATTERNS, this.negatedWorkspacePatterns].flat();
+    return [...entry, TEST_FILE_PATTERNS, this.negatedWorkspacePatterns].flat();
   }
 
   getProjectFilePatterns() {


### PR DESCRIPTION
Hey @webpro, we've been running into an issue where `knip` would flag our test files as being unused: https://github.com/freeCodeCamp/freeCodeCamp/actions/runs/4466295333/jobs/7844299421#step:6:193

From what I can see, this happens because our workspace config is 
```jsonc
    "client": {
// snipped
      "entry": [],
      "project": ["**/*.{js,ts,tsx}"],
// snipped 
    },
```

It was a relatively small change to get things working again, so I figured a PR was in order.

Hope this helps.