### PR TITLE
fix(svelte): layout reset reported as false positive (unused file)

### DIFF
--- a/src/plugins/svelte/README.md
+++ b/src/plugins/svelte/README.md
@@ -15,7 +15,7 @@ or `devDependencies`:
     "entry": [
       "svelte.config.js",
       "vite.config.ts",
-      "src/routes/**/+{page,page.server,error,layout,layout.server}.{js,ts,svelte}"
+      "src/routes/**/+{page,page.server,error,layout,layout.server}{,@*}.{js,ts,svelte}"
     ],
     "project": ["src/**/*.{js,ts,svelte}"]
   }

--- a/src/plugins/svelte/index.ts
+++ b/src/plugins/svelte/index.ts
@@ -13,7 +13,7 @@ export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDepen
 export const ENTRY_FILE_PATTERNS = ['svelte.config.js', 'vite.config.ts'];
 
 export const PRODUCTION_ENTRY_FILE_PATTERNS = [
-  "src/routes/**/+{page,page.server,error,layout,layout.server}{,@*}.{js,ts,svelte}",
+  'src/routes/**/+{page,page.server,error,layout,layout.server}{,@*}.{js,ts,svelte}',
 ];
 
 export const PROJECT_FILE_PATTERNS = ['src/**/*.{js,ts,svelte}'];

--- a/src/plugins/svelte/index.ts
+++ b/src/plugins/svelte/index.ts
@@ -13,7 +13,7 @@ export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDepen
 export const ENTRY_FILE_PATTERNS = ['svelte.config.js', 'vite.config.ts'];
 
 export const PRODUCTION_ENTRY_FILE_PATTERNS = [
-  'src/routes/**/+{page,page.server,error,layout,layout.server}.{js,ts,svelte}',
+  "src/routes/**/+{page,page.server,error,layout,layout.server}{,@*}.{js,ts,svelte}",
 ];
 
 export const PROJECT_FILE_PATTERNS = ['src/**/*.{js,ts,svelte}'];


### PR DESCRIPTION
SvelteKit has this notion of layout resets in the `src/routes` folder. It adds `@` as a reset character after e.g. `+page` or `+layout` that can be followed by name of layout group or file. These were reported as unused files by knip.

> - `+page@[id].svelte` - inherits from `src/routes/(app)/item/[id]/+layout.svelte`
> - `+page@item.svelte` - inherits from `src/routes/(app)/item/+layout.svelte`
> - `+page@(app).svelte` - inherits from `src/routes/(app)/+layout.svelte`
> - `+page@.svelte` - inherits from `src/routes/+layout.svelte`

You can find more here https://kit.svelte.dev/docs/advanced-routing#advanced-layouts-breaking-out-of-layouts .