### PR TITLE
docs: add additional svelte import paths

### DIFF
--- a/docs/compilers.md
+++ b/docs/compilers.md
@@ -77,6 +77,8 @@ export default {
   paths: {
     // This ain't pretty, but Svelte basically does the same
     '$app/*': ['node_modules/@sveltejs/kit/src/runtime/app/*'],
+    '$env/*': ['.svelte-kit/ambient.d.ts'],
+    '$lib/*': ['src/lib/*'],
   },
   compilers: {
     svelte: async (text: string) => {


### PR DESCRIPTION
SvelteKit suggests to put all non-route code to `src/lib/*` and uses`$lib/*` as import path. It also scans `.env` files and allows importing env variables through `$env/{dynamic,static}/{private,public}` so that they can be type checked and don't come as magic values. There is also `$service-worker` module but I've never used it so I don't feel comfortable suggesting path rewrite.

More info in https://kit.svelte.dev/docs/modules