### PR TITLE
Update tailwindcss plugin with .cjs support

### DIFF
--- a/src/plugins/tailwind/index.ts
+++ b/src/plugins/tailwind/index.ts
@@ -10,4 +10,4 @@ export const ENABLERS = ['tailwindcss'];
 
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-export const CONFIG_FILE_PATTERNS = ['tailwind.config.js'];
+export const CONFIG_FILE_PATTERNS = ['tailwind.config.{js,cjs}'];

--- a/src/plugins/tailwind/index.ts
+++ b/src/plugins/tailwind/index.ts
@@ -10,4 +10,4 @@ export const ENABLERS = ['tailwindcss'];
 
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-export const CONFIG_FILE_PATTERNS = ['tailwind.config.{js,cjs}'];
+export const CONFIG_FILE_PATTERNS = ['tailwind.config.{js,cjs,mjs,ts}'];


### PR DESCRIPTION
If a project had `type: module` in `package.json`.

We had to provide `tailwind.config.cjs` to work.