### PR TITLE
Unfix typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pretty-ms": "^8.0.0",
     "strip-json-comments": "^5.0.0",
     "summary": "^2.1.0",
-    "typescript": "5.0.2",
+    "typescript": "^5.0.2",
     "zod": "^3.20.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey 👋

Thanks a lot for this fantastic tool, it's **very** helpful.
I noticed that you set a fixed version of `typescript` as dependency, resulting on downloading TS 5.0.2 **and** 5.0.3.

I don't see why it should be fixed (maybe there's a reason? 😅), so I made this PR.

Thanks!