### PR TITLE
Change eslint-plugin-node to eslint-plugin-n

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:import/typescript"
   ],
-  "plugins": ["@typescript-eslint", "import", "node"],
+  "plugins": ["@typescript-eslint", "import", "n"],
   "env": {
     "node": true
   },
@@ -21,7 +21,7 @@
     }
   },
   "rules": {
-    "node/no-restricted-import": [
+    "n/no-restricted-import": [
       "error",
       [
         {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint": "8.37.0",
     "eslint-import-resolver-typescript": "3.5.4",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-node": "11.1.0",
+    "eslint-plugin-n": "15.7.0",
     "globstar": "1.0.0",
     "prettier": "2.8.7",
     "release-it": "15.10.0",

--- a/src/typescript/createHosts.ts
+++ b/src/typescript/createHosts.ts
@@ -1,5 +1,5 @@
 import { EOL } from 'node:os';
-// eslint-disable-next-line node/no-restricted-import
+// eslint-disable-next-line n/no-restricted-import
 import path from 'node:path';
 import ts from 'typescript';
 import { createCustomModuleResolver } from './resolveModuleNames.js';

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line node/no-restricted-import
+// eslint-disable-next-line n/no-restricted-import
 import path from 'node:path';
 
 const isAbsolute = path.isAbsolute;

--- a/tests/plugins/jest.test.ts
+++ b/tests/plugins/jest.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-// eslint-disable-next-line node/no-restricted-import
+// eslint-disable-next-line n/no-restricted-import
 import path from 'node:path';
 import test from 'node:test';
 import * as jest from '../../src/plugins/jest/index.js';

--- a/tests/plugins/webpack.test.ts
+++ b/tests/plugins/webpack.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-// eslint-disable-next-line node/no-restricted-import
+// eslint-disable-next-line n/no-restricted-import
 import path from 'node:path';
 import test from 'node:test';
 import { main } from '../../src/index.js';


### PR DESCRIPTION
Hey, just saw your update and wanted to point out that `eslint-plugin-node` is no longer maintained. The newer version is `eslint-plugin-n`. Keep up the great work!

https://www.npmjs.com/package/eslint-plugin-n