### PR TITLE
feat(postcss): enhance dependencies detection

### DIFF
--- a/src/plugins/postcss/index.ts
+++ b/src/plugins/postcss/index.ts
@@ -18,9 +18,17 @@ const findPostCSSDependencies: GenericPluginCallback = async (configFilePath, { 
     : await load(configFilePath);
 
   return config?.plugins
-    ? (Array.isArray(config.plugins) ? config.plugins : Object.keys(config.plugins)).filter(
-        plugin => typeof plugin === 'string'
-      )
+    ? (Array.isArray(config.plugins) ? config.plugins : Object.keys(config.plugins)).flatMap(plugin => {
+        if (typeof plugin === 'string') {
+          return plugin;
+        }
+
+        if (Array.isArray(plugin) && typeof plugin[0] === 'string') {
+          return plugin[0];
+        }
+
+        return [];
+      })
     : [];
 };
 

--- a/tests/fixtures/plugins/postcss-next/node_modules/postcss-rtlcss/index.js
+++ b/tests/fixtures/plugins/postcss-next/node_modules/postcss-rtlcss/index.js
@@ -1,0 +1,1 @@
+module.exports = function plugin() {};

--- a/tests/fixtures/plugins/postcss-next/node_modules/postcss-rtlcss/package.json
+++ b/tests/fixtures/plugins/postcss-next/node_modules/postcss-rtlcss/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "postcss-rtlcss"
+}

--- a/tests/fixtures/plugins/postcss-next/package.json
+++ b/tests/fixtures/plugins/postcss-next/package.json
@@ -4,7 +4,8 @@
     "start": "next"
   },
   "dependencies": {
-    "next": "*"
+    "next": "*",
+    "postcss-rtlcss": "*"
   },
   "postcss": {
     "plugins": [

--- a/tests/fixtures/plugins/postcss-next/postcss.config.json
+++ b/tests/fixtures/plugins/postcss-next/postcss.config.json
@@ -1,3 +1,11 @@
 {
-  "plugins": ["autoprefixer"]
+  "plugins": [
+    "autoprefixer",
+    [
+      "postcss-rtlcss",
+      {
+        "safeBothPrefix": true
+      }
+    ]
+  ]
 }


### PR DESCRIPTION
`next.js` [allows ](https://nextjs.org/docs/pages/building-your-application/configuring/post-css) to declare postcss-config like this
```
{
  "plugins": [
    "postcss-flexbugs-fixes",
    [
      "postcss-preset-env",
      {
        "autoprefixer": {
          "flexbox": "no-2009"
        },
        "stage": 3,
        "features": {
          "custom-properties": false
        }
      }
    ]
  ]
}
```

so I add more checks to detect packages