### PR TITLE
feat: add binaries type in config validator

### DIFF
--- a/src/ConfigurationValidator.ts
+++ b/src/ConfigurationValidator.ts
@@ -14,6 +14,7 @@ const issueTypeSchema = z.union([
   z.literal('dependencies'),
   z.literal('devDependencies'),
   z.literal('unlisted'),
+  z.literal('binaries'),
   z.literal('unresolved'),
   z.literal('exports'),
   z.literal('types'),


### PR DESCRIPTION
Now, if you use the TypeScript version of the config file and customize the issue types for "binaries", an error occurs. This is a microfix