### PR TITLE
Replace `bash-parser` by `@ericcornelissen/bash-parser`

### DIFF
--- a/@types/bash-parser/index.d.ts
+++ b/@types/bash-parser/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'bash-parser' {
+declare module '@ericcornelissen/bash-parser' {
   type Name = {
     type: string;
     text: string;

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "schema.json"
   ],
   "dependencies": {
+    "@ericcornelissen/bash-parser": "^0.5.2",
     "@npmcli/map-workspaces": "^3.0.4",
     "@snyk/github-codeowners": "^1.1.0",
-    "bash-parser": "^0.5.0",
     "chalk": "^5.2.0",
     "easy-table": "^1.2.0",
     "fast-glob": "^3.2.12",

--- a/src/binaries/bash-parser.ts
+++ b/src/binaries/bash-parser.ts
@@ -1,10 +1,10 @@
-import parse from 'bash-parser';
+import parse from '@ericcornelissen/bash-parser';
 import parseArgs from 'minimist';
 import { debugLogObject } from '../util/debug.js';
 import * as FallbackResolver from './resolvers/fallback.js';
 import * as KnownResolvers from './resolvers/index.js';
 import { stripBinaryPath, toBinary } from './util.js';
-import type { Node } from 'bash-parser';
+import type { Node } from '@ericcornelissen/bash-parser';
 import type { PackageJson } from 'type-fest';
 
 // https://vorpaljs.github.io/bash-parser-playground/


### PR DESCRIPTION
Relates to #72 - Replaces [`bash-parser`](https://www.npmjs.com/package/bash-parser) by my own fork of the project [`@ericcornelissen/bash-parser`](https://www.npmjs.com/package/@ericcornelissen/bash-parser).

With this fork I aim to provide dependency maintenance. Thus far this only covers the removal of a non-OSI package, namely [`curry`](https://www.npmjs.com/package/curry), from the dependency tree.

Do note that this fork does not promise to provide anything beyond dependency maintenance. A proper replacement of `bash-parser` should be preferred if available.