### PR TITLE
docs: document ci + show-progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Using workspaces in a monorepo? Please see [workspaces][1] for more details abou
       --dependencies           Shortcut for --include dependencies,unlisted,unresolved
       --exports                Shortcut for --include exports,nsExports,classMembers,types,nsTypes,enumMembers,duplicates
       --include-entry-exports  Include entry files when reporting unused exports
-      -n, --no-progress        Don't show dynamic progress updates
+      -n, --no-progress        Don't show dynamic progress updates (this is automatically enabled in CI environments)
       --reporter               Select reporter: symbols, compact, codeowners, json (default: symbols)
       --reporter-options       Pass extra options to the reporter (as JSON string, see example)
       --no-config-hints        Suppress configuration hints

--- a/src/util/cli-arguments.ts
+++ b/src/util/cli-arguments.ts
@@ -16,7 +16,7 @@ Options:
   --dependencies           Shortcut for --include dependencies,unlisted,unresolved
   --exports                Shortcut for --include exports,nsExports,classMembers,types,nsTypes,enumMembers,duplicates
   --include-entry-exports  Include entry files when reporting unused exports
-  -n, --no-progress        Don't show dynamic progress updates
+  -n, --no-progress        Don't show dynamic progress updates (this is automatically enabled in CI environments)
   --reporter               Select reporter: symbols, compact, codeowners, json (default: symbols)
   --reporter-options       Pass extra options to the reporter (as JSON string, see example)
   --no-config-hints        Suppress configuration hints


### PR DESCRIPTION
For reference, it seems to be accomplished by the `process.stdout.isTTY` value, which is set to undefined in CI (i.e. GitHub Actions).