### PR TITLE
fix(vitest): support default coverage provider

### DIFF
--- a/fixtures/plugins/vitest/vitest2.config.ts
+++ b/fixtures/plugins/vitest/vitest2.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    coverage: {
+      enabled: true,
+      all: true,
+    },
+  },
+});

--- a/src/plugins/vitest/index.ts
+++ b/src/plugins/vitest/index.ts
@@ -24,7 +24,7 @@ const findVitestDependencies: GenericPluginCallback = async configFilePath => {
   const cfg = config.test;
   const environments = cfg.environment ? [getEnvPackageName(cfg.environment)] : [];
   const reporters = getExternalReporters(cfg.reporters);
-  const coverage = cfg.coverage?.provider ? [`@vitest/coverage-${cfg.coverage.provider}`] : [];
+  const coverage = cfg.coverage ? [`@vitest/coverage-${cfg.coverage.provider ?? "v8"}`] : [];
   const setupFiles = cfg.setupFiles ? [cfg.setupFiles].flat() : [];
   const globalSetup = cfg.globalSetup ? [cfg.globalSetup].flat() : [];
   return compact([...environments, ...reporters, ...coverage, ...setupFiles, ...globalSetup]);

--- a/tests/plugins/vitest.test.ts
+++ b/tests/plugins/vitest.test.ts
@@ -13,6 +13,12 @@ test('Find dependencies in vitest configuration (vitest)', async () => {
   assert.deepEqual(dependencies, ['happy-dom', '@vitest/coverage-istanbul']);
 });
 
+test('Find dependencies in vitest configuration without coverage providers (vitest)', async () => {
+  const configFilePath = join(cwd, 'vitest2.config.ts');
+  const dependencies = await vitest.findDependencies(configFilePath, { manifest });
+  assert.deepEqual(dependencies, ['jsdom', '@vitest/coverage-v8']);
+});
+
 test('Find dependencies in vitest configuration (vite)', async () => {
   const configFilePath = join(cwd, 'vite.config.ts');
   const dependencies = await vitest.findDependencies(configFilePath, { manifest });


### PR DESCRIPTION
Vitest has a default coverage provider, v8, but knip detects it as an unused dependency.
We can safely assume the user uses Vitest's coverage if the config file contains the `coverage` field, so this PR uses `v8` as the default provider if `provider` is not set.

https://vitest.dev/guide/coverage.html#coverage-providers