### PR TITLE
webpack: handle a couple more cfg.entry formats

### DIFF
--- a/src/plugins/webpack/index.ts
+++ b/src/plugins/webpack/index.ts
@@ -70,15 +70,25 @@ const findWebpackDependencies: GenericPluginCallback = async (configFilePath, { 
       const dependencies = (config.module?.rules?.flatMap(resolveRuleSetDependencies) ?? []).map(loader =>
         loader.replace(/\?.*/, '')
       );
-      const entries = (
-        cfg.entry
-          ? typeof cfg.entry === 'string'
-            ? [cfg.entry]
-            : Array.isArray(cfg.entry)
-            ? cfg.entry
-            : Object.values(cfg.entry).map(entry => (typeof entry === 'string' ? entry : entry.filename))
-          : []
-      ).map(entry => (config.context ? join(config.context, entry) : entry));
+      let entries: string[] = [];
+
+      if (typeof cfg.entry === "string") entries.push(cfg.entry);
+      else if (Array.isArray(cfg.entry)) entries.push(...cfg.entry);
+      else if (typeof cfg.entry === "object") {
+        Object.values(cfg.entry).map(entry => {
+          if (typeof entry === "string") entries.push(entry);
+          else if (Array.isArray(entry)) entries.push(...entry);
+          else if (entry && typeof entry === "object" && "filename" in entry) entries.push(entry["filename"] as string);
+          else {
+            // TODO: warn about unrecognized single entry in object
+          }
+        });
+      } else {
+        // TODO: warn about unrecognized entry structure
+      }
+
+      entries = entries.map(entry => (config.context ? join(config.context, entry) : entry));
+
       return [...dependencies, ...entries];
     });
   });

--- a/src/plugins/webpack/index.ts
+++ b/src/plugins/webpack/index.ts
@@ -72,14 +72,14 @@ const findWebpackDependencies: GenericPluginCallback = async (configFilePath, { 
       );
       let entries: string[] = [];
 
-      if (typeof cfg.entry === "string") entries.push(cfg.entry);
+      if (typeof cfg.entry === 'string') entries.push(cfg.entry);
       else if (Array.isArray(cfg.entry)) entries.push(...cfg.entry);
-      else if (typeof cfg.entry === "object") {
+      else if (typeof cfg.entry === 'object') {
         Object.values(cfg.entry).map(entry => {
-          if (typeof entry === "string") entries.push(entry);
+          if (typeof entry === 'string') entries.push(entry);
           else if (Array.isArray(entry)) entries.push(...entry);
-          else if (typeof entry === "function") entries.push((entry as () => string)());
-          else if (entry && typeof entry === "object" && "filename" in entry) entries.push(entry["filename"] as string);
+          else if (typeof entry === 'function') entries.push((entry as () => string)());
+          else if (entry && typeof entry === 'object' && 'filename' in entry) entries.push(entry['filename'] as string);
           else {
             // TODO: warn about unrecognized single entry in object
           }

--- a/src/plugins/webpack/index.ts
+++ b/src/plugins/webpack/index.ts
@@ -78,6 +78,7 @@ const findWebpackDependencies: GenericPluginCallback = async (configFilePath, { 
         Object.values(cfg.entry).map(entry => {
           if (typeof entry === "string") entries.push(entry);
           else if (Array.isArray(entry)) entries.push(...entry);
+          else if (typeof entry === "function") entries.push((entry as () => string)());
           else if (entry && typeof entry === "object" && "filename" in entry) entries.push(entry["filename"] as string);
           else {
             // TODO: warn about unrecognized single entry in object

--- a/src/plugins/webpack/index.ts
+++ b/src/plugins/webpack/index.ts
@@ -80,12 +80,7 @@ const findWebpackDependencies: GenericPluginCallback = async (configFilePath, { 
           else if (Array.isArray(entry)) entries.push(...entry);
           else if (typeof entry === 'function') entries.push((entry as () => string)());
           else if (entry && typeof entry === 'object' && 'filename' in entry) entries.push(entry['filename'] as string);
-          else {
-            // TODO: warn about unrecognized single entry in object
-          }
         });
-      } else {
-        // TODO: warn about unrecognized entry structure
       }
 
       entries = entries.map(entry => (config.context ? join(config.context, entry) : entry));

--- a/src/plugins/webpack/index.ts
+++ b/src/plugins/webpack/index.ts
@@ -70,7 +70,7 @@ const findWebpackDependencies: GenericPluginCallback = async (configFilePath, { 
       const dependencies = (config.module?.rules?.flatMap(resolveRuleSetDependencies) ?? []).map(loader =>
         loader.replace(/\?.*/, '')
       );
-      let entries: string[] = [];
+      const entries: string[] = [];
 
       if (typeof cfg.entry === 'string') entries.push(cfg.entry);
       else if (Array.isArray(cfg.entry)) entries.push(...cfg.entry);
@@ -83,9 +83,7 @@ const findWebpackDependencies: GenericPluginCallback = async (configFilePath, { 
         });
       }
 
-      entries = entries.map(entry => (config.context ? join(config.context, entry) : entry));
-
-      return [...dependencies, ...entries];
+      return [...dependencies, ...entries.map(entry => (config.context ? join(config.context, entry) : entry))];
     });
   });
 


### PR DESCRIPTION
This fixes a crash I was getting in my project based on Razzle.js, because the Webpack plugin code wasn't handling all of the cases that can happen in the configuration's `entry` field. (Specifically, when the entry is an object and its keys are of type `string[]`.)

This is also a little more defensively written and (IMO) easier to understand.

Based on the TS types here:

https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/types.d.ts#L2396-L2400