### PR TITLE
Include declaration files when resolving import specifiers

### DIFF
--- a/fixtures/dts/package.json
+++ b/fixtures/dts/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@fixtures/dts"
+}

--- a/fixtures/dts/src/assets.d.ts
+++ b/fixtures/dts/src/assets.d.ts
@@ -1,0 +1,1 @@
+declare module '*.html?raw';

--- a/fixtures/dts/src/block.html
+++ b/fixtures/dts/src/block.html
@@ -1,0 +1,1 @@
+<div>content</div>

--- a/fixtures/dts/src/index.ts
+++ b/fixtures/dts/src/index.ts
@@ -1,0 +1,4 @@
+import b from './block.html?raw';
+import n from './normal';
+
+console.log(b, n);

--- a/fixtures/dts/src/normal.ts
+++ b/fixtures/dts/src/normal.ts
@@ -1,0 +1,1 @@
+export default 1;

--- a/fixtures/dts/tsconfig.json
+++ b/fixtures/dts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "include": ["./src/assets.d.ts", "./src"],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/src/ProjectPrincipal.ts
+++ b/src/ProjectPrincipal.ts
@@ -27,7 +27,6 @@ const baseCompilerOptions = {
   esModuleInterop: true,
   skipDefaultLibCheck: true,
   skipLibCheck: true,
-  lib: [],
   target: ts.ScriptTarget.Latest,
   module: ts.ModuleKind.CommonJS,
   moduleResolution: ts.ModuleResolutionKind.NodeNext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,9 +132,12 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
 
     deputy.addWorkspace({ name, dir, manifestPath, manifest, ignoreDependencies, ignoreBinaries });
 
-    const compilerOptions = await loadCompilerOptions(join(dir, tsConfigFile ?? 'tsconfig.json'));
+    const { compilerOptions, definitionPaths } = await loadCompilerOptions(join(dir, tsConfigFile ?? 'tsconfig.json'));
 
     const principal = factory.getPrincipal({ cwd: dir, paths, compilerOptions, compilers });
+
+    // Pushing declaration files to the program as source files seems not enough
+    principal.addEntryPaths(definitionPaths);
 
     const worker = new WorkspaceWorker({
       name,

--- a/src/plugins/typescript/index.ts
+++ b/src/plugins/typescript/index.ts
@@ -5,7 +5,6 @@ import { hasDependency, load } from '../../util/plugin.js';
 import { loadTSConfig } from '../../util/tsconfig-loader.js';
 import type { IsPluginEnabledCallback, GenericPluginCallback } from '../../types/plugins.js';
 import type { TsConfigJson } from 'type-fest';
-import type { CompilerOptions } from 'typescript';
 
 // https://www.typescriptlang.org/tsconfig
 
@@ -34,7 +33,7 @@ const resolveExtensibleConfig = async (configFilePath: string) => {
 };
 
 const findTypeScriptDependencies: GenericPluginCallback = async configFilePath => {
-  const compilerOptions: CompilerOptions = await loadTSConfig(configFilePath);
+  const { compilerOptions } = await loadTSConfig(configFilePath);
   const config: TsConfigJson = await resolveExtensibleConfig(configFilePath); // Dual loader to get external `extends` dependencies
 
   if (!compilerOptions || !config) return [];

--- a/src/typescript/SourceFileManager.ts
+++ b/src/typescript/SourceFileManager.ts
@@ -16,6 +16,7 @@ export class SourceFileManager {
 
   createSourceFile(filePath: string, contents: string) {
     const setParentNodes = isInternal(filePath);
+    // When added explicitly, declaration files are created properly with `.isDeclarationFile: true`
     const sourceFile = ts.createSourceFile(filePath, contents, ts.ScriptTarget.Latest, setParentNodes);
     this.sourceFileCache.set(filePath, sourceFile);
     return sourceFile;

--- a/src/typescript/getImportsAndExports.ts
+++ b/src/typescript/getImportsAndExports.ts
@@ -84,6 +84,7 @@ export const getImportsAndExports = (sourceFile: BoundSourceFile, options: GetIm
     const { specifier, symbol, identifier = '__anonymous', isReExport = false } = options;
     if (isBuiltin(specifier)) return;
 
+    // The specifier exists, but no resolved module
     const module = sourceFile.resolvedModules?.get(specifier, /* mode */ undefined);
 
     if (module?.resolvedModule) {

--- a/src/typescript/resolveModuleNames.ts
+++ b/src/typescript/resolveModuleNames.ts
@@ -11,6 +11,7 @@ export function createCustomModuleResolver(
   }
 
   function resolveModuleName(name: string, containingFile: string): ts.ResolvedModule | undefined {
+    // How to let TypeScript know about the declaration files to resolve e.g. the `*.html?raw` import specifier?
     const tsResolvedModule = ts.resolveModuleName(name, containingFile, compilerOptions, ts.sys).resolvedModule;
 
     if (virtualFileExtensions.length === 0) return tsResolvedModule;

--- a/src/util/tsconfig-loader.ts
+++ b/src/util/tsconfig-loader.ts
@@ -6,7 +6,15 @@ export const loadTSConfig = async (tsConfigFilePath: string) => {
   if (isFile(tsConfigFilePath)) {
     const config = ts.readConfigFile(tsConfigFilePath, ts.sys.readFile);
     const parsedConfig = ts.parseJsonConfigFileContent(config.config, ts.sys, dirname(tsConfigFilePath));
-    return parsedConfig.options ?? {};
+    const compilerOptions = parsedConfig.options ?? {};
+
+    // Local declaration files pushed to `lib: []` seem not be taken into account by ts.resolveModuleName()
+    // const definitionPaths = parsedConfig.fileNames.filter(filePath => filePath.endsWith('.d.ts'));
+    // compilerOptions.lib = compilerOptions.lib ?? [];
+    // compilerOptions.lib.push(...definitionPaths);
+    const definitionPaths: string[] = [];
+
+    return { compilerOptions, definitionPaths };
   }
-  return {};
+  return { compilerOptions: {}, definitionPaths: [] };
 };


### PR DESCRIPTION
When a project has declaration files (`.d.ts`) added through e.g. the `include: []` configuration in `tsconfig.json`, how to get `ts.resolveModuleName()` take them into account?

This PR includes a fixture that has `assets.d.ts`:

```
declare module '*.html?raw';
```

With a module importing another:

```
import b from './block.html?raw';
```

The result with Knip is an unresolved module, since I don't know how to properly include the declaration files in the TypeScript backend. Full repro:

```
$ git clone -b fix/include-dts git@github.com:webpro/knip.git
$ cd knip
$ npm install
$ cd fixtures/dts/
$ npx knip
Unused files (1)
src/assets.d.ts
Unresolved imports (1)
./block.html?raw  src/index.ts
```

The TypeScript backend is set up mainly in the [constructor of the ProjectPrincipal class](https://github.com/webpro/knip/blob/93fecdabcdcc2324c69256bce3d886cbc3fb8046/src/ProjectPrincipal.ts#L72-L103) using a [language service and compiler host in createHosts.ts](https://github.com/webpro/knip/blob/main/src/typescript/createHosts.ts) with a [custom resolveModuleNames](https://github.com/webpro/knip/blob/main/src/typescript/resolveModuleNames.ts) function.

In this PR I have added some code and comments to indicate where the relevant bits are.

To rephrase my question: how to properly include declaration files not explicitly included through import statements?

(By the way, the current workaround in Knip is to let this slip through and eventually sanitize the import specifiers and ignore specifiers having an [extension from this list](https://github.com/webpro/knip/blob/main/src/constants.ts#L48-L67).)