### PR TITLE
fix: add middleware.ts to default nextjs config plugin

### DIFF
--- a/fixtures/nextjs/next.config.js
+++ b/fixtures/nextjs/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/fixtures/nextjs/package.json
+++ b/fixtures/nextjs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/nextjs",
+  "dependencies": {
+    "next": "*"
+  }
+}

--- a/fixtures/nextjs/src/app/page.tsx
+++ b/fixtures/nextjs/src/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Page</div>;
+};

--- a/fixtures/nextjs/src/middleware.ts
+++ b/fixtures/nextjs/src/middleware.ts
@@ -1,0 +1,3 @@
+export function middleware() {
+  console.log('log from middleware')
+}

--- a/fixtures/nextjs/tsconfig.json
+++ b/fixtures/nextjs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/src/plugins/next/README.md
+++ b/src/plugins/next/README.md
@@ -12,7 +12,13 @@ or `devDependencies`:
 ```json
 {
   "next": {
-    "entry": ["next.config.{js,ts,cjs,mjs}", "{app,pages}/**/*.{js,jsx,ts,tsx}", "src/{app,pages}/**/*.{js,jsx,ts,tsx}"]
+    "entry": [
+      "next.config.{js,ts,cjs,mjs}",
+      "{app,pages}/**/*.{js,jsx,ts,tsx}",
+      "src/{app,pages}/**/*.{js,jsx,ts,tsx}",
+      "middleware.{js,ts}",
+      "src/middleware.{js,ts}"
+    ]
   }
 }
 ```

--- a/src/plugins/next/index.ts
+++ b/src/plugins/next/index.ts
@@ -15,4 +15,6 @@ export const ENTRY_FILE_PATTERNS = ['next.config.{js,ts,cjs,mjs}'];
 export const PRODUCTION_ENTRY_FILE_PATTERNS = [
   '{app,pages}/**/*.{js,jsx,ts,tsx}',
   'src/{app,pages}/**/*.{js,jsx,ts,tsx}',
+  'middleware.{js,ts}',
+  'src/middleware.{js,ts}',
 ];

--- a/tests/nextjs.test.ts
+++ b/tests/nextjs.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../src/index.js';
+import { resolve } from '../src/util/path.js';
+import baseArguments from './helpers/baseArguments.js';
+import baseCounters from './helpers/baseCounters.js';
+
+test('Support NextJS files', async () => {
+  const cwd = resolve('fixtures/nextjs');
+
+  const { counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  console.log({ counters });
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    dependencies: 0,
+    processed: 3,
+    total: 3,
+  });
+});


### PR DESCRIPTION
## Description
NextJS supports a feature named [middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware). However, the plugin for Next does not list middleware.ts as a possible entry point causing knip command to fail (example repo [here](https://github.com/surbina/nextjs-middleware-knip-test)).

This PR adds middleware.ts as possible entry point to the NextJS plugin. It also adds a test to validate it's working as expected.