### PR TITLE
change '.json' to '.ts' for different location for the knip file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ const config: KnipConfig = {
 export default config;
 ```
 
-Use `--config path/to/knip.json` to use a different location.
+Use `--config path/to/knip.ts` to use a different location.
 
 ### Let's Go!
 


### PR DESCRIPTION
I guess the example to use a different location for knip  file extension should be `.ts` because dynamic file example has TypeScript file 



<img width="980" alt="Screenshot 2023-09-01 at 21 44 52" src="https://github.com/webpro/knip/assets/15308039/c7167577-b632-46c0-b9fc-ccae3f13aae2">
