### PR TITLE
Add Next.js instrumentation hook to entry file patterns

### DIFF
--- a/src/plugins/next/README.md
+++ b/src/plugins/next/README.md
@@ -17,7 +17,9 @@ or `devDependencies`:
       "{app,pages}/**/*.{js,jsx,ts,tsx}",
       "src/{app,pages}/**/*.{js,jsx,ts,tsx}",
       "middleware.{js,ts}",
-      "src/middleware.{js,ts}"
+      "src/middleware.{js,ts}",
+      "instrumentation.{js,ts}",
+      "src/instrumentation.{js,ts}"
     ]
   }
 }

--- a/src/plugins/next/index.ts
+++ b/src/plugins/next/index.ts
@@ -17,4 +17,6 @@ export const PRODUCTION_ENTRY_FILE_PATTERNS = [
   'src/{app,pages}/**/*.{js,jsx,ts,tsx}',
   'middleware.{js,ts}',
   'src/middleware.{js,ts}',
+  'instrumentation.{js,ts}',
+  'src/instrumentation.{js,ts}',
 ];


### PR DESCRIPTION
Adds [Next.js's instrumentation file](https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation) to the entry file patterns for the Next.js plugin.