### PR TITLE
Simplify array.from+map

### DIFF
--- a/src/PrincipalFactory.ts
+++ b/src/PrincipalFactory.ts
@@ -76,6 +76,6 @@ export class PrincipalFactory {
   }
 
   public getPrincipals() {
-    return Array.from(this.principals).map(p => p.principal);
+    return Array.from(this.principals, p => p.principal);
   }
 }


### PR DESCRIPTION
`Array.from` has optional second argument. Calling `map` is not required for this case.