### PR TITLE
Optimize findManifestDependencies

### DIFF
--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -18,7 +18,7 @@ const findManifestDependencies = async ({ manifest, isProduction, isStrict, dir,
 
   const scripts = Object.entries(manifest.scripts ?? {}).reduce((scripts, [scriptName, script]) => {
     if (script && (scriptFilter.length === 0 || scriptFilter.includes(scriptName))) {
-      return scripts.push(script);
+      scripts.push(script);
     }
     return scripts;
   }, [] as string[]);

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -18,7 +18,7 @@ const findManifestDependencies = async ({ manifest, isProduction, isStrict, dir,
 
   const scripts = Object.entries(manifest.scripts ?? {}).reduce((scripts, [scriptName, script]) => {
     if (script && (scriptFilter.length === 0 || scriptFilter.includes(scriptName))) {
-      return [...scripts, script];
+      return scripts.push(script);
     }
     return scripts;
   }, [] as string[]);


### PR DESCRIPTION
Spread creates a new array in each iteration, resulting in a complexity of O(n*n). Using `push` has a complexity of O(n) and does not create a new array.