### PR TITLE
feat: add --preprocessor-options flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Knip takes the following JSDoc/TSDoc tags into account:
       --include-entry-exports  Include entry files when reporting unused exports
       -n, --no-progress        Don't show dynamic progress updates (automatically enabled in CI environments)
       --preprocessor           Preprocess the results before providing it to the reporter(s), can be repeated
+      --preprocessor-options   Pass extra options to the preprocessor (as JSON string, see --reporter-options example)
       --reporter               Select reporter: symbols, compact, codeowners, json, can be repeated (default: symbols)
       --reporter-options       Pass extra options to the reporter (as JSON string, see example)
       --no-config-hints        Suppress configuration hints

--- a/fixtures/cli-preprocessor/node_modules/with-args/index.ts
+++ b/fixtures/cli-preprocessor/node_modules/with-args/index.ts
@@ -1,0 +1,4 @@
+export default function (options) {
+  console.log(`hi from with-args preprocessor, you gave me: ${JSON.parse(options.preprocessorOptions).food}`);
+  return options;
+}

--- a/fixtures/cli-preprocessor/node_modules/with-args/package.json
+++ b/fixtures/cli-preprocessor/node_modules/with-args/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "with-args"
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ const {
   performance: isObservePerf = false,
   production: isProduction = false,
   'reporter-options': reporterOptions = '',
+  'preprocessor-options': preprocessorOptions = '',
   strict: isStrict = false,
   tsConfig,
   version: isVersion,
@@ -66,6 +67,7 @@ const run = async () => {
       isProduction,
       isShowProgress,
       options: reporterOptions,
+      preprocessorOptions,
     };
 
     const finalData = await runPreprocessors(initialData);

--- a/src/types/issues.ts
+++ b/src/types/issues.ts
@@ -58,6 +58,7 @@ export type ReporterOptions = {
   isProduction: boolean;
   isShowProgress: boolean;
   options: string;
+  preprocessorOptions: string;
 };
 
 export type Reporter = (options: ReporterOptions) => void;

--- a/src/util/cli-arguments.ts
+++ b/src/util/cli-arguments.ts
@@ -19,6 +19,7 @@ Options:
   --include-entry-exports  Include entry files when reporting unused exports
   -n, --no-progress        Don't show dynamic progress updates (automatically enabled in CI environments)
   --preprocessor           Preprocess the results before providing it to the reporter(s), can be repeated
+  --preprocessor-options   Pass extra options to the preprocessor (as JSON string, see --reporter-options example)
   --reporter               Select reporter: symbols, compact, codeowners, json, can be repeated (default: symbols)
   --reporter-options       Pass extra options to the reporter (as JSON string, see example)
   --no-config-hints        Suppress configuration hints
@@ -65,6 +66,7 @@ try {
       performance: { type: 'boolean' },
       production: { type: 'boolean' },
       preprocessor: { type: 'string', multiple: true },
+      'preprocessor-options': { type: 'string' },
       reporter: { type: 'string', multiple: true },
       'reporter-options': { type: 'string' },
       strict: { type: 'boolean' },

--- a/tests/cli-preprocessor.test.ts
+++ b/tests/cli-preprocessor.test.ts
@@ -6,13 +6,8 @@ import { resolve } from '../src/util/path.js';
 const cwd = resolve('fixtures/cli-preprocessor');
 
 const exec = (command: string) => {
-  try {
-    const output = execSync(command.replace(/^knip/, 'node ../../dist/cli.js'), { cwd });
-    return output.toString().trim();
-  } catch (e) {
-    console.error(e.stdout.toString());
-    throw e;
-  }
+  const output = execSync(command.replace(/^knip/, 'node ../../dist/cli.js'), { cwd });
+  return output.toString().trim();
 };
 
 test('knip --preprocessor ./index.js', () => {

--- a/tests/cli-preprocessor.test.ts
+++ b/tests/cli-preprocessor.test.ts
@@ -6,8 +6,13 @@ import { resolve } from '../src/util/path.js';
 const cwd = resolve('fixtures/cli-preprocessor');
 
 const exec = (command: string) => {
-  const output = execSync(command.replace(/^knip/, 'node ../../dist/cli.js'), { cwd });
-  return output.toString().trim();
+  try {
+    const output = execSync(command.replace(/^knip/, 'node ../../dist/cli.js'), { cwd });
+    return output.toString().trim();
+  } catch (e) {
+    console.error(e.stdout.toString());
+    throw e;
+  }
 };
 
 test('knip --preprocessor ./index.js', () => {
@@ -24,4 +29,11 @@ test('knip --preprocessor knip-preprocessor', () => {
 
 test('knip --preprocessor @org/preprocessor', () => {
   assert.equal(exec('knip --preprocessor @org/preprocessor'), 'hi from scoped preprocessor');
+});
+
+test(`knip --preprocessor with-args --preprocessor-options {"food":"cupcake"}`, () => {
+  assert.equal(
+    exec(`knip --preprocessor with-args --preprocessor-options {\\"food\\":\\"cupcake\\"}`),
+    'hi from with-args preprocessor, you gave me: cupcake'
+  );
 });


### PR DESCRIPTION
Adds a `--preprocessor-options` flag, to allow preprocessors to access separate options from reporters. I've opted to pass it in as a separate preprocessorOptions parameter, so that preprocessors still have access to the eventual reporter options.

I can change it to use the options field instead if preferred.