### PR TITLE
Mark .ts files as entrypoints inside Next.js app dir

### DIFF
--- a/src/plugins/next/index.ts
+++ b/src/plugins/next/index.ts
@@ -18,8 +18,8 @@ const productionEntryFilePatternsWithoutSrc = [
   'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,ts,tsx}',
   'instrumentation.{js,ts}',
   'app/{manifest,sitemap,robots}.{js,ts}',
-  'app/**/{icon,apple-icon}-image.{js,jsx,ts,tsx}',
-  'app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}',
+  'app/**/{icon,apple-icon}-image.{js,ts,tsx}',
+  'app/**/{opengraph,twitter}-image.{js,ts,tsx}',
   'pages/**/*.{js,jsx,ts,tsx}',
 ];
 

--- a/src/plugins/next/index.ts
+++ b/src/plugins/next/index.ts
@@ -18,8 +18,8 @@ const productionEntryFilePatternsWithoutSrc = [
   'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,ts,tsx}',
   'instrumentation.{js,ts}',
   'app/{manifest,sitemap,robots}.{js,ts}',
-  'app/**/{icon,apple-icon}-image.{js,ts,ts,tsx}',
-  'app/**/{opengraph,twitter}-image.{js,ts,ts,tsx}',
+  'app/**/{icon,apple-icon}-image.{js,jsx,ts,tsx}',
+  'app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}',
   'pages/**/*.{js,jsx,ts,tsx}',
 ];
 

--- a/src/plugins/next/index.ts
+++ b/src/plugins/next/index.ts
@@ -15,11 +15,11 @@ export const ENTRY_FILE_PATTERNS = ['next.config.{js,ts,cjs,mjs}'];
 const productionEntryFilePatternsWithoutSrc = [
   'middleware.{js,ts}',
   'app/**/route.{js,ts}',
-  'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,tsx}',
+  'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,ts,tsx}',
   'instrumentation.{js,ts}',
   'app/{manifest,sitemap,robots}.{js,ts}',
-  'app/**/{icon,apple-icon}-image.{js,ts,tsx}',
-  'app/**/{opengraph,twitter}-image.{js,ts,tsx}',
+  'app/**/{icon,apple-icon}-image.{js,ts,ts,tsx}',
+  'app/**/{opengraph,twitter}-image.{js,ts,ts,tsx}',
   'pages/**/*.{js,jsx,ts,tsx}',
 ];
 


### PR DESCRIPTION
I have a `page.ts` file that simply performs a redirect without involving JSX. It's also possible that a page simply re-exports a component defined elsewhere.