### PR TITLE
add `tsconfig.*.json` pattern to the typescript plugin

### DIFF
--- a/src/plugins/typescript/README.md
+++ b/src/plugins/typescript/README.md
@@ -12,7 +12,7 @@ or `devDependencies`:
 ```json
 {
   "typescript": {
-    "config": ["tsconfig.json"]
+    "config": ["tsconfig.json", "tsconfig.*.json"]
   }
 }
 ```

--- a/src/plugins/typescript/index.ts
+++ b/src/plugins/typescript/index.ts
@@ -51,8 +51,8 @@ const findTypeScriptDependencies: GenericPluginCallback = async configFilePath =
   const jsx = compilerOptions?.jsxImportSource
     ? [compilerOptions.jsxImportSource]
     : compilerOptions?.jsx && jsxWithReact.includes(compilerOptions.jsx)
-      ? ['react']
-      : [];
+    ? ['react']
+    : [];
   return compact([...extend, ...types, ...plugins, ...importHelpers, ...jsx]);
 };
 

--- a/src/plugins/typescript/index.ts
+++ b/src/plugins/typescript/index.ts
@@ -17,7 +17,7 @@ export const ENABLERS = ['typescript'];
 
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-export const CONFIG_FILE_PATTERNS = ['tsconfig.json'];
+export const CONFIG_FILE_PATTERNS = ['tsconfig.json', 'tsconfig.*.json'];
 
 const resolveExtensibleConfig = async (configFilePath: string) => {
   const config: TsConfigJson = await load(configFilePath);
@@ -51,8 +51,8 @@ const findTypeScriptDependencies: GenericPluginCallback = async configFilePath =
   const jsx = compilerOptions?.jsxImportSource
     ? [compilerOptions.jsxImportSource]
     : compilerOptions?.jsx && jsxWithReact.includes(compilerOptions.jsx)
-    ? ['react']
-    : [];
+      ? ['react']
+      : [];
   return compact([...extend, ...types, ...plugins, ...importHelpers, ...jsx]);
 };
 


### PR DESCRIPTION
The `tsconfig.*.json`, often used when you have multiple `tsconfig` per project, is common enough in the ecosystem so I think that's a reasonable addition.

`typescript-eslint` is a good example: https://typescript-eslint.io/linting/typed-linting/monorepos/#one-root-tsconfigjson