### PR TITLE
Add support for Storybook test runner's hook api

### DIFF
--- a/src/plugins/storybook/README.md
+++ b/src/plugins/storybook/README.md
@@ -13,7 +13,7 @@ or `devDependencies`:
 ```json
 {
   "storybook": {
-    "config": [".storybook/{main,manager}.{js,ts}"],
+    "config": [".storybook/{main,manager,test-runner}.{js,ts}"],
     "entry": [".storybook/preview.{js,jsx,ts,tsx}", "**/*.stories.{js,jsx,ts,tsx}"],
     "project": [".storybook/**/*.{js,jsx,ts,tsx}"]
   }

--- a/src/plugins/storybook/index.ts
+++ b/src/plugins/storybook/index.ts
@@ -12,7 +12,7 @@ export const ENABLERS = [/^@storybook\//, '@nrwl/storybook'];
 
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-export const CONFIG_FILE_PATTERNS = ['.storybook/{main,manager}.{js,ts}'];
+export const CONFIG_FILE_PATTERNS = ['.storybook/{main,manager,test-runner}.{js,ts}'];
 
 export const ENTRY_FILE_PATTERNS = ['.storybook/preview.{js,jsx,ts,tsx}', '**/*.stories.{js,jsx,ts,tsx}'];
 


### PR DESCRIPTION
The test hook api is configurable using the `.storybook/test-runner.{js,ts}` file.

Docs: https://storybook.js.org/docs/react/writing-tests/test-runner#test-hook-api-experimental