### PR TITLE
Add jest's `testResultsProcessor` to dependency check

### DIFF
--- a/fixtures/plugins/jest/jest.config.js
+++ b/fixtures/plugins/jest/jest.config.js
@@ -24,4 +24,5 @@ module.exports = {
       testMatch: ['<rootDir>/**/*.js'],
     },
   ],
+  testResultsProcessor: 'jest-result-processor'
 };

--- a/src/plugins/jest/index.ts
+++ b/src/plugins/jest/index.ts
@@ -61,6 +61,7 @@ const resolveDependencies = (config: Config.InitialOptions): string[] => {
       ? Object.values(config.moduleNameMapper).map(mapper => (typeof mapper === 'string' ? mapper : mapper[0]))
       : []
   ).filter(value => !/\$[0-9]/.test(value));
+  const testResultsProcessor = config.testResultsProcessor ? [config.testResultsProcessor] : [];
 
   return [
     ...presets,
@@ -74,6 +75,7 @@ const resolveDependencies = (config: Config.InitialOptions): string[] => {
     ...setupFilesAfterEnv,
     ...transform,
     ...moduleNameMapper,
+    ...testResultsProcessor,
   ];
 };
 

--- a/tests/plugins/jest.test.ts
+++ b/tests/plugins/jest.test.ts
@@ -23,5 +23,6 @@ test('Find dependencies in Jest configuration (jest.config.js)', async () => {
     join(cwd, 'jest.transform.js'),
     join(cwd, '__mocks__/fileMock.js'),
     'identity-obj-proxy',
+    'jest-result-processor',
   ]);
 });


### PR DESCRIPTION
Dependencies such as [jest-sonar-reporter](https://www.npmjs.com/package/jest-sonar-reporter) are used in the `testResultsProcessor` config from jest, and are currently not being considered as used dependency by knip.

This PR adds that configuration to the jest's plugin for resolving jest's dependencies.