### PR TITLE
Fix pattern for icons in Next apps

### DIFF
--- a/src/plugins/next/index.ts
+++ b/src/plugins/next/index.ts
@@ -18,7 +18,7 @@ const productionEntryFilePatternsWithoutSrc = [
   'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,ts,tsx}',
   'instrumentation.{js,ts}',
   'app/{manifest,sitemap,robots}.{js,ts}',
-  'app/**/{icon,apple-icon}-image.{js,ts,tsx}',
+  'app/**/{icon,apple-icon}.{js,ts,tsx}',
   'app/**/{opengraph,twitter}-image.{js,ts,tsx}',
   'pages/**/*.{js,jsx,ts,tsx}',
 ];


### PR DESCRIPTION
https://nextjs.org/docs/app/api-reference/file-conventions/metadata/app-icons#generate-icons-using-code-js-ts-tsx

`-image` part is not present for icons.