### PR TITLE
feat: allow gatsby plugin to see local plugins as entrypoints

### DIFF
--- a/src/plugins/gatsby/README.md
+++ b/src/plugins/gatsby/README.md
@@ -13,13 +13,17 @@ or `devDependencies`:
 ```json
 {
   "gatsby": {
-    "config": ["gatsby-{config,node}.{js,jsx,ts,tsx}"],
+    "config": [
+      "gatsby-{config,node}.{js,jsx,ts,tsx}",
+      "plugins/**/gatsby-node.{js,jsx,ts,tsx}"
+    ],
     "entry": [
       "gatsby-{browser,ssr}.{js,jsx,ts,tsx}",
       "src/api/**/*.{js,ts}",
       "src/pages/**/*.{js,jsx,ts,tsx}",
       "src/templates/**/*.{js,jsx,ts,tsx}",
-      "src/html.{js,jsx,ts,tsx}"
+      "src/html.{js,jsx,ts,tsx}",
+      "plugins/**/gatsby-{browser,ssr}.{js,jsx,ts,tsx}"
     ]
   }
 }

--- a/src/plugins/gatsby/index.ts
+++ b/src/plugins/gatsby/index.ts
@@ -13,7 +13,10 @@ export const ENABLERS = ['gatsby', 'gatsby-cli'];
 
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-export const CONFIG_FILE_PATTERNS = ['gatsby-{config,node}.{js,jsx,ts,tsx}'];
+export const CONFIG_FILE_PATTERNS = [
+  'gatsby-{config,node}.{js,jsx,ts,tsx}',
+  'plugins/**/gatsby-node.{js,jsx,ts,tsx}',
+];
 
 export const PRODUCTION_ENTRY_FILE_PATTERNS = [
   'gatsby-{browser,ssr}.{js,jsx,ts,tsx}',
@@ -21,6 +24,7 @@ export const PRODUCTION_ENTRY_FILE_PATTERNS = [
   'src/pages/**/*.{js,jsx,ts,tsx}',
   'src/templates/**/*.{js,jsx,ts,tsx}',
   'src/html.{js,jsx,ts,tsx}',
+  'plugins/**/gatsby-{browser,ssr}.{js,jsx,ts,tsx}',
 ];
 
 const findGatsbyDependencies: GenericPluginCallback = async configFilePath => {


### PR DESCRIPTION
Gatsby allows "local plugins" in the plugins folder that don't exist as full proper workspaces, but instead are run by Gatsby itself. This PR modifies the Gatsby plugin to include the "local plugins" folders by default, so these are included.

Plugins don't have a gatsby-config like the main site does, so I made the config entry only take the gatsby-node file.