### PR TITLE
Add binaries to JSON reporter

### DIFF
--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -52,6 +52,7 @@ export default async ({ report, issues, options }: ReporterOptions) => {
       ...(report.devDependencies && { devDependencies: [] }),
       ...(report.optionalPeerDependencies && { optionalPeerDependencies: [] }),
       ...(report.unlisted && { unlisted: [] }),
+      ...(report.binaries && { binaries: [] }),
       ...(report.unresolved && { unresolved: [] }),
       ...((report.exports || report.nsExports) && { exports: [] }),
       ...((report.types || report.nsTypes) && { types: [] }),


### PR DESCRIPTION
I'm currently working on a simple github action that will comment on a PR with the report outputs from the JSON report and noticed that the `binaries` field was missing in the json blob.

Also noticed a small mistake in the documentation around the report keys