### PR TITLE
Use path.relative instead of path.posix.relative for relative paths

### DIFF
--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -16,8 +16,7 @@ export const cwd = toPosix(process.cwd());
 export const resolve = (...paths: string[]) =>
   paths.length === 1 ? path.posix.join(cwd, paths[0]) : path.posix.resolve(...paths);
 
-export const relative = (from: string, to?: string) =>
-  path.posix.relative(to ? toPosix(from) : cwd, toPosix(to ?? from));
+export const relative = (from: string, to?: string) => toPosix(path.relative(to ? from : cwd, to ?? from));
 
 export const isInNodeModules = (filePath: string) => filePath.includes('node_modules');
 


### PR DESCRIPTION
On Windows calling:

```js
path.posix.relative('C:/Users/Brian/10ten-ja-reader', '.')
```

will produce `../../../..`.

I believe what it does in this case is run `path.posix.resolve()` on both arguments producing `/Users/Brian/C:/Users/Brian/10ten-ja-reader` and `/Users/Brian` and then determines the relative between the two giving us `../../../..`.

If we use `path.relative` instead, which does not try to resolve both paths to posix paths first, we get the expected result, an empty string:

> If `from` and `to` each resolve to the same path (after calling
> `path.resolve()` on each), a zero-length string is returned.

(Source: https://nodejs.org/api/path.html#pathrelativefrom-to)

We'll still probably want to convert the result of _that_ to a posix path using our `toPosix` helper, in order to be consistent with how we handle paths elsewhere, otherwise we'll get results with backslashes in them.

I've so far only observed an incorrect result coming about from the `'.'` input and that only from the Playwright plugin so an alternative fix might be to get the Playwright plugin to stop producing relative paths of the form `'.'` but I suspect this could show up in other places.