### PR TITLE
Support new Nx npm scope

### DIFF
--- a/fixtures/plugins/nx/apps/b/project.json
+++ b/fixtures/plugins/nx/apps/b/project.json
@@ -1,0 +1,18 @@
+{
+  "sourceRoot": "apps/b",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "@nx/next:build"
+    },
+    "serve": {
+      "executor": "@nx/next:server"
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint"
+    },
+    "test": {
+      "executor": "@js/cypress:cypress"
+    }
+  }
+}

--- a/fixtures/plugins/nx/package.json
+++ b/fixtures/plugins/nx/package.json
@@ -4,6 +4,9 @@
     "nx": "nx"
   },
   "devDependencies": {
+    "@nx/next": "*",
+    "@nx/linter": "*",
+    "@nx/cypress": "*",
     "@nrwl/cypress": "*",
     "@nrwl/devkit": "*",
     "@nrwl/jest": "*",

--- a/src/plugins/nx/index.ts
+++ b/src/plugins/nx/index.ts
@@ -8,7 +8,7 @@ import type { IsPluginEnabledCallback, GenericPluginCallback } from '../../types
 export const NAME = 'Nx';
 
 /** @public */
-export const ENABLERS = ['nx', /^@nrwl\//];
+export const ENABLERS = ['nx', /^@nrwl\//, /^@nx\//];
 
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 


### PR DESCRIPTION
Since nx version 16, they changed their npm scope from `@nrwl/*` to `@nx/*`. I've added a change to ensure both are detected.

See more about this change [here](https://nx.dev/recipes/other/rescope).