### PR TITLE
Support postcss cjs file format

### DIFF
--- a/fixtures/plugins/postcss-cjs/node_modules/autoprefixer/index.js
+++ b/fixtures/plugins/postcss-cjs/node_modules/autoprefixer/index.js
@@ -1,0 +1,1 @@
+module.exports = function plugin() {};

--- a/fixtures/plugins/postcss-cjs/node_modules/autoprefixer/package.json
+++ b/fixtures/plugins/postcss-cjs/node_modules/autoprefixer/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "autoprefixer"
+}

--- a/fixtures/plugins/postcss-cjs/node_modules/postcss/package.json
+++ b/fixtures/plugins/postcss-cjs/node_modules/postcss/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "postcss",
+  "bin": "./cli.js"
+}

--- a/fixtures/plugins/postcss-cjs/package.json
+++ b/fixtures/plugins/postcss-cjs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@fixtures/postcss-cjs",
+  "scripts": {
+    "postcss": "postcss"
+  },
+  "devDependencies": {
+    "postcss": "*"
+  },
+  "postcss": {
+    "plugins": [
+      "autoprefixer"
+    ]
+  }
+}

--- a/fixtures/plugins/postcss-cjs/postcss.config.cjs
+++ b/fixtures/plugins/postcss-cjs/postcss.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('autoprefixer')],
+};

--- a/src/plugins/postcss/README.md
+++ b/src/plugins/postcss/README.md
@@ -13,7 +13,7 @@ or `devDependencies`:
 ```json
 {
   "postcss": {
-    "config": ["postcss.config.js", "postcss.config.json", "package.json"]
+    "config": ["postcss.config.{cjs,js}", "postcss.config.json", "package.json"]
   }
 }
 ```

--- a/src/plugins/postcss/index.ts
+++ b/src/plugins/postcss/index.ts
@@ -10,7 +10,7 @@ export const ENABLERS = ['postcss', 'next'];
 
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-export const CONFIG_FILE_PATTERNS = ['postcss.config.js', 'postcss.config.json', 'package.json'];
+export const CONFIG_FILE_PATTERNS = ['postcss.config.{cjs,js}', 'postcss.config.json', 'package.json'];
 
 const findPostCSSDependencies: GenericPluginCallback = async (configFilePath, options) => {
   const { manifest, isProduction } = options;

--- a/test/plugins/postcss-cjs.test.ts
+++ b/test/plugins/postcss-cjs.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.js';
+import * as postcss from '../../src/plugins/postcss/index.js';
+import { resolve, join } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+import { getManifest } from '../helpers/index.js';
+
+const cwd = resolve('fixtures/plugins/postcss-cjs');
+const manifestFilePath = join(cwd, 'package.json');
+const manifest = getManifest(cwd);
+
+test('Find dependencies in PostCSS configuration (package.json)', async () => {
+  const dependencies = await postcss.findDependencies(manifestFilePath, { manifest });
+  assert.deepEqual(dependencies, ['autoprefixer']);
+});
+
+test('Find dependencies in PostCSS configuration (postcss.config.cjs)', async () => {
+  const configFilePath = join(cwd, 'postcss.config.cjs');
+  const dependencies = await postcss.findDependencies(configFilePath, { manifest });
+  assert.deepEqual(dependencies, []);
+});
+
+test('Find dependencies in PostCSS configuration (postcss.config.cjs function)', async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert(issues.unlisted['package.json']['autoprefixer']);
+  assert(issues.unlisted['postcss.config.cjs']['autoprefixer']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    unlisted: 2,
+    processed: 1,
+    total: 1,
+  });
+});


### PR DESCRIPTION
Fixes #256

Right now, the postcss dosn't support a `.cjs` file name, this PR fixes that !

I'v added : 
- [x] Docs
- [x] Tests

Feel free to request any changes you see fit !