### PR TITLE
Symbols reporter: output file path with line number

### DIFF
--- a/src/reporters/symbols.ts
+++ b/src/reporters/symbols.ts
@@ -16,7 +16,12 @@ const logIssueRecord = (issues: Issue[]) => {
     table.cell('symbol', print(issue.symbols ? truncate(issue.symbols.join(', ')) : issue.symbol));
     issue.parentSymbol && table.cell('parentSymbol', print(issue.parentSymbol));
     issue.symbolType && table.cell('symbolType', print(issue.symbolType));
-    table.cell('filePath', print(relative(issue.filePath)));
+    const filePath = `${relative(issue.filePath)}${
+      issue.line === undefined
+        ? ""
+        : `:${issue.line}${issue.col === undefined ? "" : `:${issue.col}`}`
+    }`;
+    table.cell('filePath', print(filePath));
     table.newRow();
   });
   console.log(table.sort(['filePath', 'parentSymbol', 'symbol']).print().trim());


### PR DESCRIPTION
Makes it possible to open the file at the issue line number

Demo:

https://github.com/webpro/knip/assets/643434/69114379-5994-4de6-a06c-34119d1af595

