### PR TITLE
Use @latest for npx commands in doc

### DIFF
--- a/packages/docs/src/content/docs/overview/getting-started.mdx
+++ b/packages/docs/src/content/docs/overview/getting-started.mdx
@@ -102,21 +102,21 @@ Alternatively, try Knip without adding it to your project:
   <TabItem label="npm">
 
     ```shell
-    npx knip
+    npx knip@latest
     ```
 
   </TabItem>
   <TabItem label="pnpm">
 
     ```shell
-    pnpm dlx knip
+    pnpm dlx knip@latest
     ```
 
   </TabItem>
   <TabItem label="bun">
 
     ```shell
-    bunx knip
+    bunx knip@latest
     ```
 
   </TabItem>


### PR DESCRIPTION
When developing https://github.com/getsentry/sentry-wizard we found that users ran into a lot of bugs because they weren't using the latest version of the package via the npx command.

This patch updates the docs to explicitly add `knip@latest` so that users will get the most up to date version of knip when copying the command from the docs.