### PR TITLE
adds support for `package.json` shared prettier configuration

### DIFF
--- a/packages/knip/fixtures/plugins/prettier/package.json
+++ b/packages/knip/fixtures/plugins/prettier/package.json
@@ -1,0 +1,3 @@
+{
+  "prettier": "@company/prettier-config"
+}

--- a/packages/knip/src/plugins/prettier/index.ts
+++ b/packages/knip/src/plugins/prettier/index.ts
@@ -27,6 +27,11 @@ const findPrettierDependencies: GenericPluginCallback = async (configFilePath, {
     ? manifest.prettier
     : await load(configFilePath);
 
+  // https://prettier.io/docs/en/configuration.html#sharing-configurations
+  if (typeof localConfig === 'string') {
+    return [localConfig];
+  }
+
   return localConfig && Array.isArray(localConfig.plugins)
     ? localConfig.plugins.filter((plugin): plugin is string => typeof plugin === 'string')
     : [];

--- a/packages/knip/test/plugins/prettier.test.ts
+++ b/packages/knip/test/plugins/prettier.test.ts
@@ -2,11 +2,19 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as prettier from '../../src/plugins/prettier/index.js';
 import { resolve, join } from '../../src/util/path.js';
+import { getManifest } from '../helpers/index.js';
 
 const cwd = resolve('fixtures/plugins/prettier');
+const manifest = getManifest(cwd);
 
-test('Find dependencies in Prettier configuration', async () => {
+test('Find dependencies in Prettier configuration (.prettierrc)', async () => {
   const configFilePath = join(cwd, '.prettierrc');
   const dependencies = await prettier.findDependencies(configFilePath, {});
   assert.deepEqual(dependencies, ['prettier-plugin-xml']);
+});
+
+test('Find dependencies in Prettier configuration (package.json)', async () => {
+  const configFilePath = join(cwd, 'package.json');
+  const dependencies = await prettier.findDependencies(configFilePath, {manifest});
+  assert.deepEqual(dependencies, ['@company/prettier-config']);
 });


### PR DESCRIPTION
Prettier supports using a dependency as configuration, as mentioned in [their documentation](https://prettier.io/docs/en/configuration.html#sharing-configurations), and is currently not being detected by knip.

This PR detects if this configuration type is being used, and adds it to the dependency list.