### PR TITLE
vitest: Detect whether coverage is enabled in npm scripts

### DIFF
--- a/packages/knip/fixtures/plugins/vitest-npm-script/package.json
+++ b/packages/knip/fixtures/plugins/vitest-npm-script/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixtures/vitest-npm-script",
+  "scripts": {
+    "test:coverage": "vitest --coverage"
+  },
+  "devDependencies": {
+    "vitest": "^0.34.6"
+  }
+}

--- a/packages/knip/fixtures/plugins/vitest-npm-script/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/vitest-npm-script/vitest.config.ts
@@ -1,0 +1,8 @@
+export default {
+  test: {
+    coverage: {
+      enabled: false,
+      provider: 'v8',
+    },
+  },
+};

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -5,6 +5,7 @@ import { hasDependency, load, tryResolve } from '../../util/plugin.js';
 import { toEntryPattern } from '../../util/protocols.js';
 import { getEnvPackageName, getExternalReporters } from './helpers.js';
 import type { ViteConfigOrFn, VitestWorkspaceConfig, ViteConfig, MODE, COMMAND } from './types.js';
+import type { PackageJsonWithPlugins } from '../../types/package-json.js';
 import type {
   IsPluginEnabledCallback,
   GenericPluginCallback,
@@ -36,12 +37,19 @@ const resolveEntry = (containingFilePath: string, specifier: string) => {
   return specifier;
 };
 
+const hasScriptWithCoverage = (scripts: Exclude<PackageJsonWithPlugins['scripts'], undefined>) => {
+  return Object.values(scripts).some((script) => {
+    return script.startsWith('vitest') &&
+           (script.includes('--coverage') || script.includes('--coverage.enabled=true'))
+  });
+}
+
 const findConfigDependencies = (
   configFilePath: string,
   localConfig: ViteConfig,
   options: GenericPluginCallbackOptions
 ) => {
-  const { isProduction, config } = options;
+  const { isProduction, config, manifest } = options;
   const testConfig = localConfig.test;
 
   const entryPatterns = (config?.entry ?? testConfig?.include ?? ENTRY_FILE_PATTERNS).map(toEntryPattern);
@@ -50,10 +58,11 @@ const findConfigDependencies = (
 
   const environments = testConfig.environment ? [getEnvPackageName(testConfig.environment)] : [];
   const reporters = getExternalReporters(testConfig.reporters);
-  const coverage =
-    testConfig.coverage && testConfig.coverage.enabled !== false
-      ? [`@vitest/coverage-${testConfig.coverage.provider ?? 'v8'}`]
-      : [];
+
+  const hasCoverageEnabled = (testConfig.coverage && testConfig.coverage.enabled !== false) ||
+                             (manifest.scripts !== undefined && hasScriptWithCoverage(manifest.scripts))
+  const coverage = hasCoverageEnabled ? [`@vitest/coverage-${testConfig.coverage?.provider ?? 'v8'}`] : [];
+
   const setupFiles = [testConfig.setupFiles ?? []].flat().map(v => resolveEntry(configFilePath, v));
   const globalSetup = [testConfig.globalSetup ?? []].flat().map(v => resolveEntry(configFilePath, v));
   return [...entryPatterns, ...environments, ...reporters, ...coverage, ...setupFiles, ...globalSetup];

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -37,12 +37,13 @@ const resolveEntry = (containingFilePath: string, specifier: string) => {
   return specifier;
 };
 
+const enablesCoverageInScript = /vitest(.+)--coverage(?:\.enabled(?:=true)?)?/;
+
 const hasScriptWithCoverage = (scripts: Exclude<PackageJsonWithPlugins['scripts'], undefined>) => {
-  return Object.values(scripts).some((script) => {
-    return script.startsWith('vitest') &&
-           (script.includes('--coverage') || script.includes('--coverage.enabled=true'))
+  return Object.values(scripts).some(script => {
+    return enablesCoverageInScript.test(script);
   });
-}
+};
 
 const findConfigDependencies = (
   configFilePath: string,
@@ -59,8 +60,9 @@ const findConfigDependencies = (
   const environments = testConfig.environment ? [getEnvPackageName(testConfig.environment)] : [];
   const reporters = getExternalReporters(testConfig.reporters);
 
-  const hasCoverageEnabled = (testConfig.coverage && testConfig.coverage.enabled !== false) ||
-                             (manifest.scripts !== undefined && hasScriptWithCoverage(manifest.scripts))
+  const hasCoverageEnabled =
+    (testConfig.coverage && testConfig.coverage.enabled !== false) ||
+    (manifest.scripts !== undefined && hasScriptWithCoverage(manifest.scripts));
   const coverage = hasCoverageEnabled ? [`@vitest/coverage-${testConfig.coverage?.provider ?? 'v8'}`] : [];
 
   const setupFiles = [testConfig.setupFiles ?? []].flat().map(v => resolveEntry(configFilePath, v));

--- a/packages/knip/test/plugins/prettier.test.ts
+++ b/packages/knip/test/plugins/prettier.test.ts
@@ -15,6 +15,6 @@ test('Find dependencies in Prettier configuration (.prettierrc)', async () => {
 
 test('Find dependencies in Prettier configuration (package.json)', async () => {
   const configFilePath = join(cwd, 'package.json');
-  const dependencies = await prettier.findDependencies(configFilePath, {manifest});
+  const dependencies = await prettier.findDependencies(configFilePath, { manifest });
   assert.deepEqual(dependencies, ['@company/prettier-config']);
 });

--- a/packages/knip/test/plugins/vitest-npm-script.test.ts
+++ b/packages/knip/test/plugins/vitest-npm-script.test.ts
@@ -10,8 +10,5 @@ const manifest = getManifest(cwd);
 test('detects the coverage dependency when a npm script activates coverage', async () => {
   const configFilePath = join(cwd, 'vitest.config.ts');
   const dependencies = await vitest.findDependencies(configFilePath, { cwd, manifest, config });
-  assert.deepEqual(dependencies, [
-    'entry:**/*.{test,spec}.?(c|m)[jt]s?(x)',
-    '@vitest/coverage-v8',
-  ]);  
+  assert.deepEqual(dependencies, ['entry:**/*.{test,spec}.?(c|m)[jt]s?(x)', '@vitest/coverage-v8']);
 });

--- a/packages/knip/test/plugins/vitest-npm-script.test.ts
+++ b/packages/knip/test/plugins/vitest-npm-script.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as vitest from '../../src/plugins/vitest/index.js';
+import { resolve, join } from '../../src/util/path.js';
+import { getManifest, pluginConfig as config } from '../helpers/index.js';
+
+const cwd = resolve('fixtures/plugins/vitest-npm-script');
+const manifest = getManifest(cwd);
+
+test('detects the coverage dependency when a npm script activates coverage', async () => {
+  const configFilePath = join(cwd, 'vitest.config.ts');
+  const dependencies = await vitest.findDependencies(configFilePath, { cwd, manifest, config });
+  assert.deepEqual(dependencies, [
+    'entry:**/*.{test,spec}.?(c|m)[jt]s?(x)',
+    '@vitest/coverage-v8',
+  ]);  
+});


### PR DESCRIPTION
This fixes #372 by doing base searches for either `--coverage` or `coverage.enabled=true` for commands starting with `vitest`. This should be good enough but does not account for e.g. npx or for overriding the [coverage instrumenter](https://github.com/search?q=--coverage.provider&type=code) in the command line arguments.

<details>
	<summary>Unfortunately the "test" script in the root did not work for me</summary>

```js
node --no-warnings --test tmp

node:internal/modules/cjs/loader:1147
  throw err;
  ^

Error: Cannot find module '/home/dany/dev/forks/knip/packages/knip/tmp'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Module._load (node:internal/modules/cjs/loader:985:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```
</details>

But I tested by using the advice from the [guide](https://knip.dev/guides/writing-a-plugin/#tests) with `npx tsx test/plugins/vitest-npm-script.test.ts` run from `packages/knip` folder.
