### PR TITLE
fix(schema): Added "binaries" to `issueTypes`

### DIFF
--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -132,7 +132,8 @@
           "types",
           "nsTypes",
           "enumMembers",
-          "duplicates"
+          "duplicates",
+          "binaries"
         ]
       }
     },


### PR DESCRIPTION
The current schema identifies `binaries` as invalid when adding it the the knip config for `include` or `exclude`, however it is a valid option.