### PR TITLE
Deduplicate workspace names

### DIFF
--- a/packages/knip/src/ConfigurationChief.ts
+++ b/packages/knip/src/ConfigurationChief.ts
@@ -311,9 +311,9 @@ export class ConfigurationChief {
   }
 
   private getAvailableWorkspaceNames() {
-    return [ROOT_WORKSPACE_NAME, ...this.manifestWorkspaces.keys(), ...this.additionalWorkspaceNames].filter(
-      name => !micromatch.isMatch(name, this.ignoredWorkspacePatterns)
-    );
+    return [
+      ...new Set([ROOT_WORKSPACE_NAME, ...this.manifestWorkspaces.keys(), ...this.additionalWorkspaceNames]),
+    ].filter(name => !micromatch.isMatch(name, this.ignoredWorkspacePatterns));
   }
 
   private getAvailableWorkspaceManifests(availableWorkspaceDirs: string[]) {


### PR DESCRIPTION
It is possible that the manifest workspaces include the root workspace. In this case `ConfigurationChie#getAvailableWorkspaceNames()` would return the root name twice. This in turn would result in the root package being included twice and throw a `ConfigurationError` because of a duplicate package name.

To address this we deduplicate the workspace names.

I’d be happy to add some tests for this but I’d need some guidance where the best spot for these would be.

Fixes #390