### PR TITLE
add sveltekit entry patterns

### DIFF
--- a/packages/knip/fixtures/plugins/svelte/src/hooks.client.ts
+++ b/packages/knip/fixtures/plugins/svelte/src/hooks.client.ts
@@ -1,0 +1,8 @@
+import type { HandleClientError } from '@sveltejs/kit';
+
+export const handleError: HandleClientError = async () => {
+  return {
+    message: '',
+    errorId: '',
+  };
+};

--- a/packages/knip/fixtures/plugins/svelte/src/hooks.client.ts
+++ b/packages/knip/fixtures/plugins/svelte/src/hooks.client.ts
@@ -1,8 +1,0 @@
-import type { HandleClientError } from '@sveltejs/kit';
-
-export const handleError: HandleClientError = async () => {
-  return {
-    message: '',
-    errorId: '',
-  };
-};

--- a/packages/knip/fixtures/plugins/svelte/src/hooks.server.ts
+++ b/packages/knip/fixtures/plugins/svelte/src/hooks.server.ts
@@ -1,0 +1,6 @@
+import type { Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event);
+  return response;
+};

--- a/packages/knip/fixtures/plugins/svelte/src/hooks.server.ts
+++ b/packages/knip/fixtures/plugins/svelte/src/hooks.server.ts
@@ -1,6 +1,0 @@
-import type { Handle } from '@sveltejs/kit';
-
-export const handle: Handle = async ({ event, resolve }) => {
-  const response = await resolve(event);
-  return response;
-};

--- a/packages/knip/fixtures/plugins/svelte/src/params/lang.ts
+++ b/packages/knip/fixtures/plugins/svelte/src/params/lang.ts
@@ -1,0 +1,5 @@
+import type { ParamMatcher } from '@sveltejs/kit';
+
+export const match: ParamMatcher = param => {
+  return !!param;
+};

--- a/packages/knip/fixtures/plugins/svelte/src/params/lang.ts
+++ b/packages/knip/fixtures/plugins/svelte/src/params/lang.ts
@@ -1,5 +1,0 @@
-import type { ParamMatcher } from '@sveltejs/kit';
-
-export const match: ParamMatcher = param => {
-  return !!param;
-};

--- a/packages/knip/src/plugins/svelte/index.ts
+++ b/packages/knip/src/plugins/svelte/index.ts
@@ -19,6 +19,7 @@ export const ENTRY_FILE_PATTERNS = ['svelte.config.js', 'vite.config.ts'];
 export const PRODUCTION_ENTRY_FILE_PATTERNS = [
   'src/routes/**/+{page,server,page.server,error,layout,layout.server}{,@*}.{js,ts,svelte}',
   'src/hooks.{server,client}.{js,ts}',
+  'src/params/*{js,ts}',
 ];
 
 export const PROJECT_FILE_PATTERNS = ['src/**/*.{js,ts,svelte}'];

--- a/packages/knip/src/plugins/svelte/index.ts
+++ b/packages/knip/src/plugins/svelte/index.ts
@@ -13,7 +13,7 @@ export const ENABLERS = ['svelte'];
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
 /** @public */
-export const ENTRY_FILE_PATTERNS = ['svelte.config.js', 'vite.config.ts'];
+export const ENTRY_FILE_PATTERNS = ['svelte.config.js', 'vite.config.{js,ts}'];
 
 /** @public */
 export const PRODUCTION_ENTRY_FILE_PATTERNS = [

--- a/packages/knip/src/plugins/svelte/index.ts
+++ b/packages/knip/src/plugins/svelte/index.ts
@@ -1,6 +1,7 @@
 import { timerify } from '../../util/Performance.js';
 import { hasDependency } from '../../util/plugin.js';
 import { toEntryPattern, toProductionEntryPattern } from '../../util/protocols.js';
+import { CONFIG_FILE_PATTERNS as VITE_CONFIG_FILE_PATTERNS } from '../vite/index.js';
 import type { GenericPluginCallback, IsPluginEnabledCallback } from '../../types/plugins.js';
 
 // https://kit.svelte.dev/docs
@@ -13,7 +14,7 @@ export const ENABLERS = ['svelte'];
 export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
 /** @public */
-export const ENTRY_FILE_PATTERNS = ['svelte.config.js', 'vite.config.{js,ts}'];
+export const ENTRY_FILE_PATTERNS = ['svelte.config.js', ...VITE_CONFIG_FILE_PATTERNS];
 
 /** @public */
 export const PRODUCTION_ENTRY_FILE_PATTERNS = [

--- a/packages/knip/src/plugins/svelte/index.ts
+++ b/packages/knip/src/plugins/svelte/index.ts
@@ -18,6 +18,7 @@ export const ENTRY_FILE_PATTERNS = ['svelte.config.js', 'vite.config.ts'];
 /** @public */
 export const PRODUCTION_ENTRY_FILE_PATTERNS = [
   'src/routes/**/+{page,server,page.server,error,layout,layout.server}{,@*}.{js,ts,svelte}',
+  'src/hooks.{server,client}.{js,ts}',
 ];
 
 export const PROJECT_FILE_PATTERNS = ['src/**/*.{js,ts,svelte}'];

--- a/packages/knip/test/plugins/svelte.test.ts
+++ b/packages/knip/test/plugins/svelte.test.ts
@@ -19,7 +19,7 @@ test('Use compilers (svelte)', async () => {
   assert.deepEqual(counters, {
     ...baseCounters,
     devDependencies: 2,
-    processed: 11, // This includes .svelte and .css files
-    total: 11,
+    processed: 14, // This includes .svelte and .css files
+    total: 14,
   });
 });


### PR DESCRIPTION
This PR's adds more sveltekit entry patterns:

1. sveltekit's two optional hooks [files](https://kit.svelte.dev/docs/hooks)
2. param [matchers](https://kit.svelte.dev/docs/advanced-routing#matching)

Before this PR, knip reports the files as "unused files" (if they exist).

Additionally, I've expanded the pattern for vite.config.* (to help with this workaround: https://github.com/webpro/knip/issues/346#issuecomment-1807689199)