### PR TITLE
Add Next.js global-error entry file

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -17,6 +17,7 @@ export const ENTRY_FILE_PATTERNS = ['next.config.{js,ts,cjs,mjs}'];
 const productionEntryFilePatternsWithoutSrc = [
   'middleware.{js,ts}',
   'app/**/route.{js,ts}',
+  'app/global-error.{js,jsx,ts,tsx}',
   'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,ts,tsx}',
   'instrumentation.{js,ts}',
   'app/{manifest,sitemap,robots}.{js,ts}',


### PR DESCRIPTION
The [global-error](https://nextjs.org/docs/app/api-reference/file-conventions/error#global-errorjs) entry file is missing in the Next.js plugin.