### PR TITLE
fix: docs internal link replacement

### DIFF
--- a/packages/docs/remark/fixInternalLinks.ts
+++ b/packages/docs/remark/fixInternalLinks.ts
@@ -19,9 +19,7 @@ export const fixInternalLinks = () => (tree: Parent) => {
   const visitor: Visitor = node => {
     if (isLinkNode(node) && node.url.startsWith('.')) {
       const url = node.url;
-      node.url = url
-        .replace(/^(\.\/|\.\.\/)/, (match: string) => (match === './' ? '../' : '../../'))
-        .replace(/\.mdx?(#.+)?$/, '/$1');
+      node.url = url.replace(/\.mdx?(#.+)?$/, '$1');
       console.log(`${dim(dateTimeFormat.format(new Date()))} ${bold(cyan('[fix-link]'))} Modify ${url} → ${node.url}`);
     }
   };


### PR DESCRIPTION
- links in content: `/entry-files/` (ends with slash `/`)
- from sidebar link:  `/entry-files` (not ends with slash)

Thus, the result of specifying a link by relative paths will be different.

For example, the following cases will not transition correctly.
1. https://knip.dev/overview/getting-started/
2. click Reference Plugins (in sidebar)
3. click any plugin link
4. 404 page not found

So I unified url without slash.