### PR TITLE
Add `unbuild` plugin

### DIFF
--- a/packages/knip/fixtures/plugins/unbuild/build.config.ts
+++ b/packages/knip/fixtures/plugins/unbuild/build.config.ts
@@ -1,0 +1,5 @@
+import { defineBuildConfig } from 'unbuild';
+
+export default defineBuildConfig({
+  entries: ['./src/index'],
+});

--- a/packages/knip/fixtures/plugins/unbuild/package.json
+++ b/packages/knip/fixtures/plugins/unbuild/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/unbuild",
+  "version": "*",
+  "devDependencies": {
+    "unbuild": "^2.0.0"
+  }
+}

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -49,7 +49,9 @@
     "ignoreExportsUsedInFile": {
       "title": "Ignore exports used in file",
       "examples": [
-        { "ignoreExportsUsedInFile": true },
+        {
+          "ignoreExportsUsedInFile": true
+        },
         {
           "ignoreExportsUsedInFile": {
             "interface": true,
@@ -64,12 +66,24 @@
         {
           "type": "object",
           "properties": {
-            "class": { "type": "boolean" },
-            "enum": { "type": "boolean" },
-            "function": { "type": "boolean" },
-            "interface": { "type": "boolean" },
-            "member": { "type": "boolean" },
-            "type": { "type": "boolean" }
+            "class": {
+              "type": "boolean"
+            },
+            "enum": {
+              "type": "boolean"
+            },
+            "function": {
+              "type": "boolean"
+            },
+            "interface": {
+              "type": "boolean"
+            },
+            "member": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "boolean"
+            }
           }
         }
       ]
@@ -96,17 +110,39 @@
     "rules": {
       "type": "object",
       "properties": {
-        "classMembers": { "$ref": "#/definitions/ruleValue" },
-        "dependencies": { "$ref": "#/definitions/ruleValue" },
-        "duplicates": { "$ref": "#/definitions/ruleValue" },
-        "enumMembers": { "$ref": "#/definitions/ruleValue" },
-        "exports": { "$ref": "#/definitions/ruleValue" },
-        "files": { "$ref": "#/definitions/ruleValue" },
-        "nsExports": { "$ref": "#/definitions/ruleValue" },
-        "nsTypes": { "$ref": "#/definitions/ruleValue" },
-        "types": { "$ref": "#/definitions/ruleValue" },
-        "unlisted": { "$ref": "#/definitions/ruleValue" },
-        "unresolved": { "$ref": "#/definitions/ruleValue" }
+        "classMembers": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "dependencies": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "duplicates": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "enumMembers": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "exports": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "files": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "nsExports": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "nsTypes": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "types": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "unlisted": {
+          "$ref": "#/definitions/ruleValue"
+        },
+        "unresolved": {
+          "$ref": "#/definitions/ruleValue"
+        }
       }
     }
   },
@@ -412,6 +448,10 @@
         },
         "typescript": {
           "title": "TypeScript plugin configuration (https://github.com/webpro/knip/blob/main/src/plugins/typescript/README.md)",
+          "$ref": "#/definitions/plugin"
+        },
+        "unbuild": {
+          "title": "unbuild plugin configuration (https://github.com/webpro/knip/blob/main/src/plugins/unbuild/README.md)",
           "$ref": "#/definitions/plugin"
         },
         "vite": {

--- a/packages/knip/src/ConfigurationValidator.ts
+++ b/packages/knip/src/ConfigurationValidator.ts
@@ -121,6 +121,7 @@ const pluginsSchema = z.object({
   tsup: pluginSchema,
   typedoc: pluginSchema,
   typescript: pluginSchema,
+  unbuild: pluginSchema,
   vite: pluginSchema,
   vitest: pluginSchema,
   webpack: pluginSchema,

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -44,6 +44,7 @@ export * as tailwind from './tailwind/index.js';
 export * as tsup from './tsup/index.js';
 export * as typedoc from './typedoc/index.js';
 export * as typescript from './typescript/index.js';
+export * as unbuild from './unbuild/index.js';
 export * as vite from './vite/index.js';
 export * as vitest from './vitest/index.js';
 export * as webpack from './webpack/index.js';

--- a/packages/knip/src/plugins/unbuild/index.ts
+++ b/packages/knip/src/plugins/unbuild/index.ts
@@ -1,0 +1,26 @@
+import { timerify } from '../../util/Performance.js';
+import { hasDependency } from '../../util/plugin.js';
+import type { IsPluginEnabledCallback, GenericPluginCallback } from '../../types/plugins.js';
+
+// https://github.com/unjs/unbuild#unbuild
+
+export const NAME = 'unbuild';
+
+/** @public */
+export const ENABLERS = ['unbuild'];
+
+export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
+
+export const CONFIG_FILE_PATTERNS = ['build.config.{js,cjs,mjs,ts,mts,cts,json}'];
+
+/** @public */
+export const ENTRY_FILE_PATTERNS = [];
+
+/** @public */
+export const PRODUCTION_ENTRY_FILE_PATTERNS = [];
+
+export const PROJECT_FILE_PATTERNS = [];
+
+const findPluginDependencies: GenericPluginCallback = async () => [];
+
+export const findDependencies = timerify(findPluginDependencies);

--- a/packages/knip/src/plugins/unbuild/types.ts
+++ b/packages/knip/src/plugins/unbuild/types.ts
@@ -1,0 +1,4 @@
+export type PluginConfig = {
+  plugins?: string[];
+  entryPathsOrPatterns?: string[];
+};

--- a/packages/knip/src/plugins/unbuild/types.ts
+++ b/packages/knip/src/plugins/unbuild/types.ts
@@ -1,4 +1,15 @@
-export type PluginConfig = {
-  plugins?: string[];
-  entryPathsOrPatterns?: string[];
+export type UnbuildConfigObject = {
+  name: string;
+  entries:
+    | string[]
+    | {
+        builder: string;
+        input: string;
+        outDir: string;
+      }[];
+  outDir: string;
+  declaration: boolean;
+  rollup: Record<string, unknown>;
 };
+
+export type UnbuildConfig = Partial<UnbuildConfigObject> | Partial<UnbuildConfigObject>[];

--- a/packages/knip/test/plugins/unbuild.test.ts
+++ b/packages/knip/test/plugins/unbuild.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as unbuild from '../../src/plugins/unbuild/index.js';
+import { resolve, join } from '../../src/util/path.js';
+import { getManifest, pluginConfig as config } from '../helpers/index.js';
+import type { GenericPluginCallbackOptions } from '../../src/types/plugins.js';
+
+const cwd = resolve('fixtures/plugins/unbuild');
+const manifest = getManifest(cwd);
+
+test('Find dependencies in unbuild configuration', async () => {
+  const configFilePath = join(cwd, 'build.config.ts');
+  const dependencies = await unbuild.findDependencies(configFilePath, {
+    manifest,
+    config,
+  } as GenericPluginCallbackOptions);
+
+  assert.deepEqual(dependencies, []);
+});


### PR DESCRIPTION
Adds a plugin for [unbuild](https://github.com/unjs/unbuild). This is a super simple plugin since AFAIK there isn't any other dependencies you can use with unbuild... is there a simpler way to ignore unbuild config files automatically? Is it worth having this as a plugin?