### PR TITLE
fix: add .test-d to vitest entry files

### DIFF
--- a/packages/docs/src/content/docs/explanations/plugins.md
+++ b/packages/docs/src/content/docs/explanations/plugins.md
@@ -60,7 +60,7 @@ dependencies.
 For example, if `next` is listed as a dependency in `package.json`, the Next.js
 plugin will automatically add multiple patterns as entry files, such as
 `pages/**/*.{js,jsx,ts,tsx}`. If `vitest` is listed, the Vitest plugin adds
-`**/*.{test,spec}.ts` as entry file patterns. Most plugins have entry files
+`**/*.{test,test-d,spec}.ts` as entry file patterns. Most plugins have entry files
 configured, so you don't have to.
 
 It's mostly plugins for meta frameworks and test runners that have `entry` files

--- a/packages/knip/src/plugins/vitest/index.ts
+++ b/packages/knip/src/plugins/vitest/index.ts
@@ -27,7 +27,7 @@ export const CONFIG_FILE_PATTERNS = [
 ];
 
 /** @public */
-export const ENTRY_FILE_PATTERNS = ['**/*.{test,spec}.?(c|m)[jt]s?(x)'];
+export const ENTRY_FILE_PATTERNS = ['**/*.{test,test-d,spec}.?(c|m)[jt]s?(x)'];
 
 // TODO: Promote to something more generic, other plugins may like it too
 const resolveEntry = (containingFilePath: string, specifier: string) => {

--- a/packages/knip/test/plugins/vitest-npm-script.test.ts
+++ b/packages/knip/test/plugins/vitest-npm-script.test.ts
@@ -11,5 +11,5 @@ const enabledPlugins = ['vitest'];
 test('detects the coverage dependency when a npm script activates coverage', async () => {
   const configFilePath = join(cwd, 'vitest.config.ts');
   const dependencies = await vitest.findDependencies(configFilePath, { cwd, manifest, config, enabledPlugins });
-  assert.deepEqual(dependencies, ['entry:**/*.{test,spec}.?(c|m)[jt]s?(x)', '@vitest/coverage-v8']);
+  assert.deepEqual(dependencies, ['entry:**/*.{test,test-d,spec}.?(c|m)[jt]s?(x)', '@vitest/coverage-v8']);
 });

--- a/packages/knip/test/plugins/vitest.test.ts
+++ b/packages/knip/test/plugins/vitest.test.ts
@@ -15,7 +15,7 @@ test('Find dependencies in vitest configuration (vitest)', async () => {
   const configFilePath = join(cwd, 'vitest.config.ts');
   const dependencies = await vitest.findDependencies(configFilePath, { cwd, manifest, config, enabledPlugins });
   assert.deepEqual(dependencies, [
-    'entry:**/*.{test,spec}.?(c|m)[jt]s?(x)',
+    'entry:**/*.{test,test-d,spec}.?(c|m)[jt]s?(x)',
     'happy-dom',
     '@vitest/coverage-istanbul',
     'setup.js',
@@ -26,14 +26,14 @@ test('Find dependencies in vitest configuration (vitest)', async () => {
 test('Find dependencies in vitest configuration without coverage providers (vitest)', async () => {
   const configFilePath = join(cwd, 'vitest-default-coverage.config');
   const dependencies = await vitest.findDependencies(configFilePath, { cwd, manifest, config, enabledPlugins });
-  assert.deepEqual(dependencies, ['entry:**/*.{test,spec}.?(c|m)[jt]s?(x)', 'jsdom', '@vitest/coverage-v8']);
+  assert.deepEqual(dependencies, ['entry:**/*.{test,test-d,spec}.?(c|m)[jt]s?(x)', 'jsdom', '@vitest/coverage-v8']);
 });
 
 test('Find dependencies in vitest configuration (vite)', async () => {
   const configFilePath = join(cwd, 'vite.config.ts');
   const dependencies = await vitest.findDependencies(configFilePath, { cwd, manifest, config, enabledPlugins });
   assert.deepEqual(dependencies, [
-    'entry:**/*.{test,spec}.?(c|m)[jt]s?(x)',
+    'entry:**/*.{test,test-d,spec}.?(c|m)[jt]s?(x)',
     '@vitest/coverage-c8',
     './setup.js',
     './global.ts',


### PR DESCRIPTION
Vitest by default [accepts *.test-d.ts files as type tests](https://vitest.dev/guide/testing-types#testing-types). This is not included in the Knip Vitest plugin so it currently reports such files as unused.