### PR TITLE
Update allowed files in Next.js

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -15,14 +15,13 @@ export const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDepen
 export const ENTRY_FILE_PATTERNS = ['next.config.{js,ts,cjs,mjs}'];
 
 const productionEntryFilePatternsWithoutSrc = [
-  'middleware.{js,ts}',
-  'app/**/route.{js,ts}',
+  'middleware.{js,jsx,ts,tsx}',
   'app/global-error.{js,jsx,ts,tsx}',
-  'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,ts,tsx}',
-  'instrumentation.{js,ts}',
-  'app/{manifest,sitemap,robots}.{js,ts}',
-  'app/**/{icon,apple-icon}.{js,ts,tsx}',
-  'app/**/{opengraph,twitter}-image.{js,ts,tsx}',
+  'app/**/{error,layout,loading,not-found,page,template,route,default}.{js,jsx,ts,tsx}',
+  'instrumentation.{js,jsx,ts,tsx}',
+  'app/{manifest,sitemap,robots}.{js,jsx,ts,tsx}',
+  'app/**/{icon,apple-icon}.{js,jsx,ts,tsx}',
+  'app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}',
   'pages/**/*.{js,jsx,ts,tsx}',
 ];
 


### PR DESCRIPTION
This allows nextjs route handlers to include JSX Syntax, I noticed that knip marks these files as unused, as I use JSX route handlers to send emails with react-email. 
I also noticed that there is no allowed pattern for the `default.{js,ts,tsx,jsx}` files yet.

## Commits

- fix: allow router handlers to be jsx files, add default.{js,jsx,ts,tsx}