### PR TITLE
use the 'String#endsWith' method instead

### DIFF
--- a/packages/knip/src/util/debug.ts
+++ b/packages/knip/src/util/debug.ts
@@ -9,7 +9,9 @@ const IS_ENABLED = debug ?? false;
 const inspectOptions = { maxArrayLength: null, depth: null, colors: true };
 
 const ctx = (text: string | [string, string]) =>
-  typeof text === 'string' ? picocolors.yellow(`[${text}]`) : `${picocolors.yellow(`[${text[0]}]`)} ${picocolors.cyan(text[1])}`;
+  typeof text === 'string'
+    ? picocolors.yellow(`[${text}]`)
+    : `${picocolors.yellow(`[${text[0]}]`)} ${picocolors.cyan(text[1])}`;
 
 // Inspect arrays, otherwise Node [will, knip, ...n-100 more items]
 const logArray = (collection: string[]) => {

--- a/packages/knip/src/util/loader.ts
+++ b/packages/knip/src/util/loader.ts
@@ -13,7 +13,7 @@ const load = async (filePath: string) => {
   if (filePath === FAKE_PATH) return;
   try {
     const ext = extname(filePath);
-    if (filePath.endsWith("rc")) {
+    if (filePath.endsWith('rc')) {
       const contents = await loadFile(filePath);
       return parseYAML(contents).catch(() => parseJSON(filePath, contents));
     }

--- a/packages/knip/src/util/loader.ts
+++ b/packages/knip/src/util/loader.ts
@@ -13,7 +13,7 @@ const load = async (filePath: string) => {
   if (filePath === FAKE_PATH) return;
   try {
     const ext = extname(filePath);
-    if (/rc$/.test(filePath)) {
+    if (filePath.endsWith("rc")) {
       const contents = await loadFile(filePath);
       return parseYAML(contents).catch(() => parseJSON(filePath, contents));
     }


### PR DESCRIPTION
In the case of checking if a file path ends with `rc`, `filePath.endsWith("rc")` is likely to be faster. This is because it's a straightforward string comparison without the need for the more complex pattern matching capabilities of regular expressions.