### PR TITLE
use the "RegExp.exec()" method instead

### DIFF
--- a/packages/knip/src/plugins/markdownlint/helpers.ts
+++ b/packages/knip/src/plugins/markdownlint/helpers.ts
@@ -1,5 +1,5 @@
 export const getArgumentValues = (value: string, matcher: RegExp) => {
-  const match = value.match(matcher);
+  const match = matcher.exec(value);
   if (match) return match.map(value => value.trim().split(/[ =]/)[1].trim());
   return [];
 };

--- a/packages/knip/src/util/modules.ts
+++ b/packages/knip/src/util/modules.ts
@@ -17,7 +17,7 @@ export const getPackageNameFromFilePath = (value: string) => {
 };
 
 export const normalizeSpecifierFromFilePath = (value: string) => {
-  const match = toPosix(value).match(/.*\/node_modules\/(.+)/);
+  const match = /.*\/node_modules\/(.+)/.exec(toPosix(value));
   if (match) return match[match.length - 1];
   return value;
 };

--- a/packages/knip/src/util/tag.ts
+++ b/packages/knip/src/util/tag.ts
@@ -6,7 +6,7 @@ export const splitTags = (tags: string[]) =>
     .flatMap(tag => tag.split(','))
     .reduce<Tags>(
       ([incl, excl], tag) => {
-        (tag.startsWith('-') ? excl : incl).push(tag.match(/[a-zA-Z]+/)![0]);
+        (tag.startsWith('-') ? excl : incl).push(/[a-zA-Z]+/.exec(tag)![0]);
         return [incl, excl];
       },
       [[], []]


### PR DESCRIPTION
`String.match()` behaves the same way as `RegExp.exec()` when the regular expression does not include the global flag `g`. While they work the same, `RegExp.exec()` can be slightly faster than `String.match()`. Therefore, it should be preferred for better performance.