### PR TITLE
Add `jsx` and `tsx` in nextjs route entry

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -1,6 +1,6 @@
+import type { GenericPluginCallback, IsPluginEnabledCallback } from '../../types/plugins.js';
 import { hasDependency } from '../../util/plugin.js';
 import { toEntryPattern, toProductionEntryPattern } from '../../util/protocols.js';
-import type { GenericPluginCallback, IsPluginEnabledCallback } from '../../types/plugins.js';
 
 // https://nextjs.org/docs/getting-started/project-structure
 
@@ -16,7 +16,7 @@ const productionEntryFilePatternsWithoutSrc = [
   '{instrumentation,middleware}.{js,ts}',
   'app/global-error.{js,jsx,ts,tsx}',
   'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,ts,tsx}',
-  'app/**/{route,default}.{js,ts}',
+  'app/**/{route,default}.{js,jsx,ts,tsx}',
   'app/{manifest,sitemap,robots}.{js,ts}',
   'app/**/{icon,apple-icon}.{js,jsx,ts,tsx}',
   'app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}',


### PR DESCRIPTION
With [`vercel/og`](https://www.npmjs.com/package/@vercel/og) you often create a `route.tsx` that export a `ImageResponse` with a react component. This PR adds `tsx` and `jsx` in the entry configuration for nextjs.