### PR TITLE
Update Eleventy plugin config paths

### DIFF
--- a/packages/knip/src/plugins/eleventy/index.ts
+++ b/packages/knip/src/plugins/eleventy/index.ts
@@ -16,7 +16,7 @@ const ENABLERS = ['@11ty/eleventy'];
 
 const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-const CONFIG_FILE_PATTERNS: string[] = ['.eleventy.js', 'eleventy.config.{js,cjs}'];
+const CONFIG_FILE_PATTERNS: string[] = ['.eleventy.js', 'eleventy.config.{js,cjs,mjs}'];
 
 const ENTRY_FILE_PATTERNS: string[] = [];
 


### PR DESCRIPTION
I seem to have forgotten to add the `.mjs` extension earlier. You can see the official supported list here: https://github.com/11ty/eleventy/blob/main/src/TemplateConfig.js#L72-L75