### PR TITLE
feat: support nx crystal for nx plugin

### DIFF
--- a/packages/knip/fixtures/plugins/nx-crystal/nx.json
+++ b/packages/knip/fixtures/plugins/nx-crystal/nx.json
@@ -1,0 +1,70 @@
+{
+  "plugins": [
+    {
+      "plugin": "@nx/webpack/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "serveTargetName": "serve",
+        "previewTargetName": "preview"
+      }
+    },
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    },
+    {
+      "plugin": "@nx/playwright/plugin",
+      "options": {
+        "targetName": "e2e"
+      }
+    },
+    {
+      "plugin": "@nx/jest/plugin",
+      "options": {
+        "targetName": "test"
+      }
+    },
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "previewTargetName": "preview",
+        "testTargetName": "test",
+        "serveTargetName": "serve",
+        "serveStaticTargetName": "serve-static"
+      }
+    }
+  ],
+  "generators": {
+    "@nx/react": {
+      "application": {
+        "babel": true,
+        "style": "css",
+        "linter": "eslint",
+        "bundler": "webpack"
+      },
+      "component": {
+        "style": "css"
+      },
+      "library": {
+        "style": "css",
+        "linter": "eslint",
+        "unitTestRunner": "vitest"
+      }
+    }
+  },
+  "targetDefaults": {
+    "@nx/rollup:rollup": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
+    },
+    "my-custom-thing": {
+      "cache": true,
+      "dependsOn": ["^my-custom-thing"],
+      "inputs": ["production", "^production"]
+    }
+  }
+}

--- a/packages/knip/fixtures/plugins/nx-crystal/nx.json
+++ b/packages/knip/fixtures/plugins/nx-crystal/nx.json
@@ -65,6 +65,11 @@
       "cache": true,
       "dependsOn": ["^my-custom-thing"],
       "inputs": ["production", "^production"]
+    },
+    "test:custom-thing": {
+      "cache": true,
+      "dependsOn": ["^my-custom-thing"],
+      "inputs": ["production", "^production"]
     }
   }
 }

--- a/packages/knip/fixtures/plugins/nx-crystal/package.json
+++ b/packages/knip/fixtures/plugins/nx-crystal/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@fixtures/nx",
+  "scripts": {
+    "nx": "nx"
+  },
+  "devDependencies": {
+    "@nx/webpack": "*",
+    "@nx/eslint": "*",
+    "@nx/playwright": "*",
+    "@nx/jest": "*",
+    "@nx/vite": "*",
+    "@nx/cypress": "*",
+    "@nx/react": "*",
+    "@nx/rollup": "*",
+    "@nrwl/workspace": "*"
+  }
+}

--- a/packages/knip/fixtures/plugins/nx-crystal/package.json
+++ b/packages/knip/fixtures/plugins/nx-crystal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fixtures/nx",
+  "name": "@fixtures/nx-crystal",
   "scripts": {
     "nx": "nx"
   },

--- a/packages/knip/src/plugins/nx/index.ts
+++ b/packages/knip/src/plugins/nx/index.ts
@@ -13,7 +13,7 @@ const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(d
 
 const CONFIG_FILE_PATTERNS = ['nx.json', 'project.json', '{apps,libs}/**/project.json'];
 
-const findNxDependanciesInNxJson: GenericPluginCallback = async configFilePath => {
+const findNxDependenciesInNxJson: GenericPluginCallback = async configFilePath => {
   const localConfig: NxConfigRoot | undefined = await load(configFilePath);
 
   if (!localConfig) return [];
@@ -46,7 +46,7 @@ const findNxDependencies: GenericPluginCallback = async (configFilePath, options
   if (isProduction) return [];
 
   if (configFilePath.endsWith('nx.json')) {
-    return findNxDependanciesInNxJson(configFilePath, options);
+    return findNxDependenciesInNxJson(configFilePath, options);
   }
 
   const localConfig: NxProjectConfiguration | undefined = await load(configFilePath);

--- a/packages/knip/src/plugins/nx/index.ts
+++ b/packages/knip/src/plugins/nx/index.ts
@@ -21,7 +21,8 @@ const findNxDependanciesInNxJson: GenericPluginCallback = async configFilePath =
   const targetsDefault = localConfig.targetDefaults
     ? Object.keys(localConfig.targetDefaults)
         // Ensure we only grab executors from plugins instead of manual targets
-        .filter(it => it.includes(':'))
+        // Limiting to scoped packages to ensure we don't have false positives
+        .filter(it => it.includes(':') && it.startsWith('@'))
         .map(it => it.split(':')[0])
     : [];
 

--- a/packages/knip/src/plugins/nx/index.ts
+++ b/packages/knip/src/plugins/nx/index.ts
@@ -1,7 +1,8 @@
 import { compact } from '../../util/array.js';
+import { getPackageNameFromModuleSpecifier } from '../../util/modules.js';
 import { timerify } from '../../util/Performance.js';
 import { getDependenciesFromScripts, hasDependency, load } from '../../util/plugin.js';
-import type { NxProjectConfiguration } from './types.js';
+import type { NxConfigRoot, NxProjectConfiguration } from './types.js';
 import type { IsPluginEnabledCallback, GenericPluginCallback } from '../../types/plugins.js';
 
 const NAME = 'Nx';
@@ -10,12 +11,42 @@ const ENABLERS = ['nx', /^@nrwl\//, /^@nx\//];
 
 const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-const CONFIG_FILE_PATTERNS = ['project.json', '{apps,libs}/**/project.json'];
+const CONFIG_FILE_PATTERNS = ['nx.json', 'project.json', '{apps,libs}/**/project.json'];
+
+const findNxDependanciesInNxJson: GenericPluginCallback = async (configFilePath, options) => {
+  const localConfig: NxConfigRoot | undefined = await load(configFilePath);
+
+  if (!localConfig) return [];
+
+  const targetsDefault = localConfig.targetDefaults
+    ? Object.keys(localConfig.targetDefaults)
+        // Ensure we only grab executors from plugins instead of manual targets
+        .filter(it => it.includes(':'))
+        .map(it => it.split(':')[0])
+    : [];
+
+  const plugins =
+    localConfig.plugins && Array.isArray(localConfig.plugins)
+      ? localConfig.plugins.map(it => getPackageNameFromModuleSpecifier(it.plugin)).filter(value => value !== undefined)
+      : [];
+
+  const generators = localConfig.generators
+    ? Object.keys(localConfig.generators)
+        .map(it => getPackageNameFromModuleSpecifier(it))
+        .filter(value => value !== undefined)
+    : [];
+
+  return compact([...targetsDefault, ...plugins, ...generators]);
+};
 
 const findNxDependencies: GenericPluginCallback = async (configFilePath, options) => {
   const { isProduction } = options;
 
   if (isProduction) return [];
+
+  if (configFilePath.endsWith('nx.json')) {
+    return findNxDependanciesInNxJson(configFilePath, options);
+  }
 
   const localConfig: NxProjectConfiguration | undefined = await load(configFilePath);
 

--- a/packages/knip/src/plugins/nx/index.ts
+++ b/packages/knip/src/plugins/nx/index.ts
@@ -13,7 +13,7 @@ const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(d
 
 const CONFIG_FILE_PATTERNS = ['nx.json', 'project.json', '{apps,libs}/**/project.json'];
 
-const findNxDependanciesInNxJson: GenericPluginCallback = async (configFilePath, options) => {
+const findNxDependanciesInNxJson: GenericPluginCallback = async configFilePath => {
   const localConfig: NxConfigRoot | undefined = await load(configFilePath);
 
   if (!localConfig) return [];

--- a/packages/knip/src/plugins/nx/types.ts
+++ b/packages/knip/src/plugins/nx/types.ts
@@ -9,3 +9,11 @@ export interface NxProjectConfiguration {
     };
   };
 }
+
+export interface NxConfigRoot {
+  plugins?: Array<{
+    plugin: string;
+  }>
+  generators?: Record<string, unknown>;
+  targetDefaults?: Record<string, unknown>;
+}

--- a/packages/knip/test/plugins/nx-crystal.test.ts
+++ b/packages/knip/test/plugins/nx-crystal.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { default as nx } from '../../src/plugins/nx/index.js';
+import { resolve, join } from '../../src/util/path.js';
+import { buildOptions } from '../helpers/index.js';
+
+const cwd = resolve('fixtures/plugins/nx-crystal');
+const options = buildOptions(cwd);
+
+test('Find dependencies in Nx configuration nx.json', async () => {
+  const configFilePath = join(cwd, 'nx.json');
+  const dependencies = await nx.findDependencies(configFilePath, options);
+  assert.deepEqual(dependencies, [
+    '@nx/rollup',
+    '@nx/webpack',
+    '@nx/eslint',
+    '@nx/playwright',
+    '@nx/jest',
+    '@nx/vite',
+    '@nx/react',
+  ]);
+});


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
This Pr add support for the [Nx crystal project](https://dev.to/nx/what-if-nx-plugins-were-more-like-vscode-extensions-4oh0) to detect dependancies from nx.json.

I have added tests to ensure the feature works as intended.

This is a very basic support, only reading the nx.json to detect the plugins that are required.

A more advanced support would be to read the nx graph to get the computed, infered, targets to detect the run commands used. Given this will impact Knip larger (to have to import the `@nx/devkit`, to then get the actual graph), I didn't go this far _yet_. If you think this could be useful, let me know and I will open a second pr for this work! And also let me know the strategy you prefer (await import() or not, peer, optional peer or dev dependancy only, ...) given there is no other case like this from plugins from what I could find.

Furthermore, an open question for the graph parsing mode, is that there ins't a file that I could link the issue, I could link it to `nx.json` but I'm unsure it's the best way to do so.



Also, taking this opportunity to praise Knip 4, it's soo fast! Congrats on the awesome work! 🚀 