### PR TITLE
Ignore @types/bun by default

### DIFF
--- a/packages/knip/src/constants.ts
+++ b/packages/knip/src/constants.ts
@@ -85,7 +85,7 @@ export const IGNORED_FILE_EXTENSIONS = new Set([
 ]);
 
 // The `@types/node` dependency does not require the `node` dependency
-export const IGNORE_DEFINITELY_TYPED = ['node'];
+export const IGNORE_DEFINITELY_TYPED = ['node', 'bun'];
 
 export const ISSUE_TYPES: IssueType[] = [
   'files',


### PR DESCRIPTION
As the same as `@types/node`, ignore `@types/bun`.

Since `bun-types` is not supposed to install directly as stated in the [npm package docs](https://www.npmjs.com/package/bun-types), we do not need to ignore `bun-types`.