### PR TITLE
feat: improve markdown reporter

### DIFF
--- a/packages/docs/src/content/docs/features/reporters.md
+++ b/packages/docs/src/content/docs/features/reporters.md
@@ -91,16 +91,16 @@ markdown tables separated by issue types as headings, for example:
 
 ## Unlisted dependencies (2)
 
-| Name            | Location     |
-| :-------------- | :----------- |
-| unresolved      | src/index.ts |
-| @org/unresolved | src/index.ts |
+| Name            | Location          | Severity |
+| :-------------- | :---------------- | :------- |
+| unresolved      | src/index.ts:8:23 | error    |
+| @org/unresolved | src/index.ts:9:23 | error    |
 
 ## Unresolved imports (1)
 
-| Name         | Location     |
-| :----------- | :----------- |
-| ./unresolved | src/index.ts |
+| Name         | Location           | Severity |
+| :----------- | :----------------- | :------- |
+| ./unresolved | src/index.ts:10:12 | error    |
 ```
 
 ## Custom Reporters
@@ -170,7 +170,7 @@ line (can be repeated).
 The default export of the preprocessor should be a function with this interface:
 
 ```ts
-type Preprocessor = async (options: ReporterOptions) =>  ReporterOptions;
+type Preprocessor = async (options: ReporterOptions) => ReporterOptions;
 ```
 
 Like reporters, you can use local JavaScript or TypeScript files and external

--- a/packages/knip/test/cli-reporter-markdown.test.ts
+++ b/packages/knip/test/cli-reporter-markdown.test.ts
@@ -16,16 +16,16 @@ test('knip --reporter markdown', () => {
 
 ## Unlisted dependencies (2)
 
-| Name            | Location     |
-|:----------------|:-------------|
-| unresolved      | src/index.ts |
-| @org/unresolved | src/index.ts |
+| Name            | Location     | Severity |
+| :-------------- | :----------- | :------- |
+| @org/unresolved | src/index.ts | error    |
+| unresolved      | src/index.ts | error    |
 
 ## Unresolved imports (1)
 
-| Name         | Location     |
-|:-------------|:-------------|
-| ./unresolved | src/index.ts |
+| Name         | Location          | Severity |
+| :----------- | :---------------- | :------- |
+| ./unresolved | src/index.ts:8:23 | error    |
 
 `;
   const out = exec('knip --reporter markdown').stdout;


### PR DESCRIPTION
- make the output valid for prettier
- add line+col to the location of issue
- add severity as it's own column

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
