### PR TITLE
Update Next.js plugin for needed exception - for mocking with next-router-mock

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -10,7 +10,7 @@ const ENABLERS = ['next'];
 
 const isEnabled: IsPluginEnabledCallback = ({ dependencies }) => hasDependency(dependencies, ENABLERS);
 
-const ENTRY_FILE_PATTERNS = ['next.config.{js,ts,cjs,mjs}'];
+const ENTRY_FILE_PATTERNS = ['next.config.{js,ts,cjs,mjs}', 'next.navigation.{js,ts,cjs,mjs}'];
 
 const productionEntryFilePatternsWithoutSrc = [
   '{instrumentation,middleware}.{js,ts}',


### PR DESCRIPTION
missing a needed exception - needed for mocking with next-router-mock
