### PR TITLE
Add support for  cypress/support/commands.js file

### DIFF
--- a/packages/knip/src/plugins/cypress/index.ts
+++ b/packages/knip/src/plugins/cypress/index.ts
@@ -16,7 +16,7 @@ const TEST_FILE_PATTERNS = ['cypress/e2e/**/*.cy.{js,jsx,ts,tsx}'];
 
 const SUPPORT_FILE_PATTERNS = [
   'cypress/support/e2e.{js,jsx,ts,tsx}',
-  'cypress/support/commands.{js,jsx,ts,tsx}',
+  'cypress/support/commands.{js,ts}',
   'cypress/plugins/index.js', // Deprecated since Cypress v10
 ];
 

--- a/packages/knip/src/plugins/cypress/index.ts
+++ b/packages/knip/src/plugins/cypress/index.ts
@@ -16,6 +16,7 @@ const TEST_FILE_PATTERNS = ['cypress/e2e/**/*.cy.{js,jsx,ts,tsx}'];
 
 const SUPPORT_FILE_PATTERNS = [
   'cypress/support/e2e.{js,jsx,ts,tsx}',
+  'cypress/support/commands.{js,jsx,ts,tsx}',
   'cypress/plugins/index.js', // Deprecated since Cypress v10
 ];
 


### PR DESCRIPTION
https://docs.cypress.io/api/cypress-api/custom-commands

"We recommend defining queries is in your cypress/support/commands.js file, since it is loaded before any test files are evaluated via an import statement in the [supportFile](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Support-file)."