### PR TITLE
fix: make nx crystal work with standalone plugins

### DIFF
--- a/packages/knip/fixtures/plugins/nx-crystal/nx.json
+++ b/packages/knip/fixtures/plugins/nx-crystal/nx.json
@@ -35,7 +35,8 @@
         "serveTargetName": "serve",
         "serveStaticTargetName": "serve-static"
       }
-    }
+    },
+    "@nx/nuxt/plugin"
   ],
   "generators": {
     "@nx/react": {

--- a/packages/knip/src/plugins/nx/index.ts
+++ b/packages/knip/src/plugins/nx/index.ts
@@ -28,9 +28,11 @@ const findNxDependenciesInNxJson: GenericPluginCallback = async configFilePath =
 
   const plugins =
     localConfig.plugins && Array.isArray(localConfig.plugins)
-      ? localConfig.plugins.map(it => getPackageNameFromModuleSpecifier(it.plugin)).filter(value => value !== undefined)
+      ? localConfig.plugins
+          .map(item => (typeof item === 'string' ? item : item.plugin))
+          .map(it => getPackageNameFromModuleSpecifier(it))
+          .filter(value => value !== undefined)
       : [];
-
   const generators = localConfig.generators
     ? Object.keys(localConfig.generators)
         .map(it => getPackageNameFromModuleSpecifier(it))

--- a/packages/knip/src/plugins/nx/types.ts
+++ b/packages/knip/src/plugins/nx/types.ts
@@ -11,9 +11,12 @@ export interface NxProjectConfiguration {
 }
 
 export interface NxConfigRoot {
-  plugins?: Array<{
-    plugin: string;
-  }>
+  plugins?: Array<
+    | string
+    | {
+        plugin: string;
+      }
+  >;
   generators?: Record<string, unknown>;
   targetDefaults?: Record<string, unknown>;
 }

--- a/packages/knip/test/plugins/nx-crystal.test.ts
+++ b/packages/knip/test/plugins/nx-crystal.test.ts
@@ -17,6 +17,7 @@ test('Find dependencies in Nx configuration nx.json', async () => {
     '@nx/playwright',
     '@nx/jest',
     '@nx/vite',
+    '@nx/nuxt',
     '@nx/react',
   ]);
 });


### PR DESCRIPTION
Nx plugins syntax allows for using standalone `string` identifiers and not only objects. This pr addresses that to ensure knip works with string and not only the object syntax.

[Here is the json schema for the plugin key in the `nx.json` config : 
](https://github.com/nrwl/nx/blob/master/packages/nx/schemas/nx-schema.json#L499)

```json
    "plugins": {
      "oneOf": [
        {
          "type": "string",
          "description": "A plugin module to load with default options"
        },
        {
          "type": "object",
          "properties": {
            "plugin": {
              "type": "string",
              "description": "The plugin module to load"
            },
            "options": {
              "type": "object",
              "description": "The options passed to the plugin when creating nodes and dependencies"
            }
          }
        }
      ]
    },
```