### PR TITLE
fix truncated JSON output with JSON reporter

### DIFF
--- a/packages/knip/src/reporters/json.ts
+++ b/packages/knip/src/reporters/json.ts
@@ -98,6 +98,7 @@ export default async ({ report, issues, options }: ReporterOptions) => {
     issues: Object.values(json),
   });
 
+  // See: https://github.com/nodejs/node/issues/6379
   // @ts-expect-error _handle is private
   process.stdout._handle?.setBlocking?.(true);
   process.stdout.write(output);

--- a/packages/knip/src/reporters/json.ts
+++ b/packages/knip/src/reporters/json.ts
@@ -93,10 +93,12 @@ export default async ({ report, issues, options }: ReporterOptions) => {
     }
   }
 
-  console.log(
-    JSON.stringify({
-      files: Array.from(issues.files).map(filePath => relative(filePath)),
-      issues: Object.values(json),
-    })
-  );
+  const output = JSON.stringify({
+    files: Array.from(issues.files).map(filePath => relative(filePath)),
+    issues: Object.values(json),
+  });
+
+  // @ts-expect-error _handle is private
+  process.stdout._handle?.setBlocking?.(true);
+  process.stdout.write(output);
 };

--- a/packages/knip/src/reporters/json.ts
+++ b/packages/knip/src/reporters/json.ts
@@ -101,5 +101,5 @@ export default async ({ report, issues, options }: ReporterOptions) => {
   // See: https://github.com/nodejs/node/issues/6379
   // @ts-expect-error _handle is private
   process.stdout._handle?.setBlocking?.(true);
-  process.stdout.write(output);
+  process.stdout.write(output + '\n');
 };


### PR DESCRIPTION
Hello - I noticed that when using `--reporter=json` on a project with a lot of unused code the JSON output was truncated. This seems to be due to this known issue, a combination of large output (> 65k) followed by `process.exit()`. See this issue: https://github.com/nodejs/node/issues/6379.

I've applied the workaround documented in that (and related) issues.

Let me know if you think I should write a test for it.