### PR TITLE
Fix knip --version command

### DIFF
--- a/packages/knip/src/version.ts
+++ b/packages/knip/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '4.4.0';
+export const version = '5.0.1';

--- a/packages/knip/test/cli.test.ts
+++ b/packages/knip/test/cli.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { helpText } from '../src/util/cli-arguments.js';
+import { loadJSON } from '../src/util/fs.js';
 import { resolve } from '../src/util/path.js';
 import { version } from '../src/version.js';
 import { execFactory } from './helpers/exec.js';
@@ -9,8 +10,11 @@ const cwd = resolve('fixtures/cli');
 
 const exec = execFactory(cwd);
 
-test('knip --version', () => {
+test('knip --version', async () => {
   assert.equal(exec('knip --version').stdout, version);
+
+  const contents = await loadJSON(resolve('package.json'));
+  assert.equal(version, contents.version);
 });
 
 test('knip --help', () => {


### PR DESCRIPTION
Hi! This PR bumps the constant string in `version.ts` and updates the test implementation to ensure that the string doesn't get out of sync with `package.json` again.

I may or may not have gone on a goose chase through my NPM setup when `knip --version` was return 4.4.0 earlier today.