### PR TITLE
Improve configuration of `include/exclude` types for better discoverability

### DIFF
--- a/packages/knip/src/ConfigurationValidator.ts
+++ b/packages/knip/src/ConfigurationValidator.ts
@@ -61,8 +61,8 @@ const rootConfigurationSchema = z.object({
 });
 
 const reportConfigSchema = z.object({
-  include: z.array(z.string()).optional(),
-  exclude: z.array(z.string()).optional(),
+  include: z.array(issueTypeSchema).optional(),
+  exclude: z.array(issueTypeSchema).optional(),
 });
 
 export const pluginSchema = z.union([

--- a/packages/knip/src/types/config.ts
+++ b/packages/knip/src/types/config.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ConfigurationValidator, pluginSchema } from '../ConfigurationValidator.js';
 import * as Plugins from '../plugins/index.js';
-import type { Rules } from './issues.js';
+import type { Rules, IssueType } from './issues.js';
 import type { SyncCompilers, AsyncCompilers } from '../compilers/types.js';
 
 export type RawConfiguration = z.infer<typeof ConfigurationValidator>;
@@ -40,8 +40,8 @@ type IgnorableExport = 'class' | 'enum' | 'function' | 'interface' | 'member' | 
 
 export interface Configuration {
   rules: Rules;
-  include: string[];
-  exclude: string[];
+  include: IssueType[];
+  exclude: IssueType[];
   ignore: NormalizedGlob;
   ignoreBinaries: IgnorePatterns;
   ignoreDependencies: IgnorePatterns;


### PR DESCRIPTION
Currently `include` and `exclude` options in config are of type `string[]`. But these are already validated by `zod` to conform to `issueTypeSchema`, e.g. `files`, `dependencies` etc.

This PR improves types of `include` and `exclude` so that allowed values could be type-checked and also improves config discoverability without the need to refer to the docs.
