### PR TITLE
Add documented type for second string arg to compilers

### DIFF
--- a/packages/docs/src/content/docs/features/compilers.md
+++ b/packages/docs/src/content/docs/features/compilers.md
@@ -40,7 +40,7 @@ be a dynamic `.js` or `.ts` file.
 The compiler function interface is straightforward. Text in, text out:
 
 ```ts
-(source: string) => string;
+(source: string, filename: string) => string;
 ```
 
 This may also be an `async` function.

--- a/packages/knip/src/ConfigurationValidator.ts
+++ b/packages/knip/src/ConfigurationValidator.ts
@@ -4,8 +4,8 @@ const globSchema = z.union([z.string(), z.array(z.string())]);
 
 const pathsSchema = z.record(z.string(), z.array(z.string()));
 
-const syncCompilerSchema = z.function().args(z.string()).returns(z.string());
-const asyncCompilerSchema = z.function().args(z.string()).returns(z.promise(z.string()));
+const syncCompilerSchema = z.function().args(z.string(), z.string()).returns(z.string());
+const asyncCompilerSchema = z.function().args(z.string(), z.string()).returns(z.promise(z.string()));
 const compilerSchema = z.union([syncCompilerSchema, asyncCompilerSchema]);
 const compilersSchema = z.record(z.string(), compilerSchema);
 


### PR DESCRIPTION
Fixes https://github.com/webpro/knip/issues/547

Compilers receive a filename string as their second argument, I believe this is the correct place in the zod schema to provide the definition so that they'll be available in typing.

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
