### PR TITLE
Add wrangler plugin

### DIFF
--- a/packages/knip/fixtures/plugins/wrangler/node_modules/wrangler/package.json
+++ b/packages/knip/fixtures/plugins/wrangler/node_modules/wrangler/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "wrangler",
+	"bin": "index.js"
+}

--- a/packages/knip/fixtures/plugins/wrangler/package.json
+++ b/packages/knip/fixtures/plugins/wrangler/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@fixtures/wrangler",
   "version": "*",
+  "scripts": {
+    "dev": "wrangler dev"
+  },
   "dependencies": {
     "wrangler": "^3.37.0"
   }

--- a/packages/knip/fixtures/plugins/wrangler/package.json
+++ b/packages/knip/fixtures/plugins/wrangler/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixtures/wrangler",
+  "version": "*",
+  "dependencies": {
+    "wrangler": "^3.37.0"
+  }
+}

--- a/packages/knip/fixtures/plugins/wrangler/wrangler.toml
+++ b/packages/knip/fixtures/plugins/wrangler/wrangler.toml
@@ -1,0 +1,2 @@
+name = 'test'
+main = 'worker-test-entry.ts'

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -491,6 +491,10 @@
           "title": "Wireit plugin configuration (https://github.com/webpro/knip/blob/main/src/plugins/wireit/README.md)",
           "$ref": "#/definitions/plugin"
         },
+        "wrangler": {
+          "title": "wrangler plugin configuration (https://github.com/webpro/knip/blob/main/src/plugins/wrangler/README.md)",
+          "$ref": "#/definitions/plugin"
+        },
         "yorkie": {
           "title": "yorkie plugin configuration (https://github.com/webpro/knip/blob/main/src/plugins/yorkie/README.md)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/ConfigurationValidator.ts
+++ b/packages/knip/src/ConfigurationValidator.ts
@@ -77,6 +77,7 @@ export const pluginSchema = z.union([
 ]);
 
 const pluginsSchema = z.object({
+  wrangler: pluginSchema,
   astro: pluginSchema,
   angular: pluginSchema,
   ava: pluginSchema,

--- a/packages/knip/src/ConfigurationValidator.ts
+++ b/packages/knip/src/ConfigurationValidator.ts
@@ -77,7 +77,6 @@ export const pluginSchema = z.union([
 ]);
 
 const pluginsSchema = z.object({
-  wrangler: pluginSchema,
   astro: pluginSchema,
   angular: pluginSchema,
   ava: pluginSchema,
@@ -132,6 +131,7 @@ const pluginsSchema = z.object({
   vitest: pluginSchema,
   webpack: pluginSchema,
   wireit: pluginSchema,
+  wrangler: pluginSchema,
   yorkie: pluginSchema,
 });
 

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -54,3 +54,4 @@ export { default as vue } from './vue/index.js';
 export { default as webpack } from './webpack/index.js';
 export { default as wireit } from './wireit/index.js';
 export { default as yorkie } from './yorkie/index.js';
+export { default as wrangler } from './wrangler/index.js';

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -53,5 +53,5 @@ export { default as vitest } from './vitest/index.js';
 export { default as vue } from './vue/index.js';
 export { default as webpack } from './webpack/index.js';
 export { default as wireit } from './wireit/index.js';
-export { default as yorkie } from './yorkie/index.js';
 export { default as wrangler } from './wrangler/index.js';
+export { default as yorkie } from './yorkie/index.js';

--- a/packages/knip/src/plugins/wrangler/index.ts
+++ b/packages/knip/src/plugins/wrangler/index.ts
@@ -1,0 +1,26 @@
+import { hasDependency } from '#p/util/plugin.js';
+import type { IgnorePatterns } from '#p/types/config.js';
+import type { IsPluginEnabled, Plugin, ResolveEntryPaths } from '#p/types/plugins.js';
+import type { WranglerConfig } from './types.js';
+
+// https://developers.cloudflare.com/workers/wrangler/configuration/
+
+const title = 'wrangler';
+
+const enablers: IgnorePatterns = ['wrangler'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
+
+const config: string[] = ['wrangler.{json,toml}'];
+
+const resolveEntryPaths: ResolveEntryPaths<WranglerConfig> = async config => {
+  return config.main ? [config.main] : [];
+};
+
+export default {
+  title,
+  enablers,
+  isEnabled,
+  config,
+  resolveEntryPaths,
+} satisfies Plugin;

--- a/packages/knip/src/plugins/wrangler/index.ts
+++ b/packages/knip/src/plugins/wrangler/index.ts
@@ -1,17 +1,16 @@
 import { hasDependency } from '#p/util/plugin.js';
-import type { IgnorePatterns } from '#p/types/config.js';
 import type { IsPluginEnabled, Plugin, ResolveEntryPaths } from '#p/types/plugins.js';
 import type { WranglerConfig } from './types.js';
 
 // https://developers.cloudflare.com/workers/wrangler/configuration/
 
-const title = 'wrangler';
+const title = 'Wrangler';
 
-const enablers: IgnorePatterns = ['wrangler'];
+const enablers = ['wrangler'];
 
 const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependencies, enablers);
 
-const config: string[] = ['wrangler.{json,toml}'];
+const config = ['wrangler.{json,toml}'];
 
 const resolveEntryPaths: ResolveEntryPaths<WranglerConfig> = async config => {
   return config.main ? [config.main] : [];

--- a/packages/knip/src/plugins/wrangler/types.ts
+++ b/packages/knip/src/plugins/wrangler/types.ts
@@ -1,0 +1,3 @@
+export type WranglerConfig = {
+  main?: string;
+};

--- a/packages/knip/test/plugins/wrangler.test.ts
+++ b/packages/knip/test/plugins/wrangler.test.ts
@@ -8,12 +8,10 @@ import baseCounters from '../helpers/baseCounters.js';
 const cwd = resolve('fixtures/plugins/wrangler');
 
 test('Find dependencies with the wrangler plugin', async () => {
-  const { /* issues, */ counters } = await main({
+  const { counters } = await main({
     ...baseArguments,
     cwd,
   });
-
-  // console.log(issues);
 
   assert.deepEqual(counters, {
     ...baseCounters,

--- a/packages/knip/test/plugins/wrangler.test.ts
+++ b/packages/knip/test/plugins/wrangler.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugins/wrangler');
+
+test('Find dependencies with the wrangler plugin', async () => {
+  const { /* issues, */ counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  // console.log(issues);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 0,
+    total: 0,
+  });
+});


### PR DESCRIPTION
Hi :wave:,

This PR aims to implement a plugin for Cloudflare Workers, or more specifically their `wrangler` cli. The config file is `wrangler.toml` with json config in experimental status (has been for quite a while), and contains one relevant entry, the main entrypoint of the worker.

I think I managed to add a correctly minimal fixture this time, the new config api made it even simpler compared to the Astro one :tada:, great work!

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
