### PR TITLE
fix: add jsx extensions for next default file convention

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -14,8 +14,8 @@ const entry = ['next.config.{js,ts,cjs,mjs}'];
 const productionEntryFilePatternsWithoutSrc = [
   '{instrumentation,middleware}.{js,ts}',
   'app/global-error.{js,jsx,ts,tsx}',
-  'app/**/{error,layout,loading,not-found,page,template}.{js,jsx,ts,tsx}',
-  'app/**/{route,default}.{js,ts}',
+  'app/**/{error,layout,loading,not-found,page,template,default}.{js,jsx,ts,tsx}',
+  'app/**/{route}.{js,ts}',
   'app/{manifest,sitemap,robots}.{js,ts}',
   'app/**/{icon,apple-icon}.{js,jsx,ts,tsx}',
   'app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}',

--- a/packages/knip/test/plugins/next.test.ts
+++ b/packages/knip/test/plugins/next.test.ts
@@ -22,7 +22,7 @@ test('Find dependencies with the Next.js plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    files: 1,
+    files: 3,
     devDependencies: 0,
     unlisted: 6,
     processed: 10,


### PR DESCRIPTION
This is currently flagged as a false positive since any `default.tsx` or `default.jsx` file is not included in the entry point of the project but are also not imported since this is a special next.js file which marks it as unused by knip.