### PR TITLE
Add engine field verification with `installed-check`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "devDependencies": {
+        "installed-check": "9.1.0"
+      },
       "peerDependencies": {
         "knip": "file:packages/knip"
       }
@@ -2897,6 +2900,23 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
+    "node_modules/@pnpm/workspace.read-manifest": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/workspace.read-manifest/-/workspace.read-manifest-1.0.3.tgz",
+      "integrity": "sha512-AC83sfZze5MzsaZjMzAgOOncOfDx8Edo1Pz5GTAFH7Pjqu1a/wFqgL+1ulyLADH5mfYQnF5olXTp7+EPXpZ4sQ==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/constants": "7.1.1",
+        "@pnpm/error": "5.0.3",
+        "read-yaml-file": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
     "node_modules/@release-it/bumper": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@release-it/bumper/-/bumper-6.0.1.tgz",
@@ -3682,6 +3702,12 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true
+    },
     "node_modules/@types/npm-package-arg": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@types/npm-package-arg/-/npm-package-arg-6.1.4.tgz",
@@ -4120,6 +4146,39 @@
       "dependencies": {
         "@volar/language-core": "2.1.6",
         "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@voxpelli/semver-set": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@voxpelli/semver-set/-/semver-set-5.0.2.tgz",
+      "integrity": "sha512-9FzdmgUi1yFTEdilUsg95wvZCN0dtqdslhWHZDCfX74ISs7vd1Gb3QgXcYPs7EqY5SEy18iZkDVoZ02HOrHkcQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@voxpelli/type-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@voxpelli/type-helpers/-/type-helpers-3.4.0.tgz",
+      "integrity": "sha512-nDPbVFZ7y7aEMAVRC1LIllMMvwE5Qgd0z+cyd+K4z0NJ7LAjcjydhPw4RYAoYF3JzvZVpra/S0SRN/dCFE8E+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@voxpelli/typed-utils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@voxpelli/typed-utils/-/typed-utils-1.7.0.tgz",
+      "integrity": "sha512-PdXqqKySZFV9lRAQ++9R2noCEHB5RGvOYD+Dl2LvcIGXO+AYPStTIdRb1peHf26UIyEjdo6gG0xp5OZ1vDTrAQ==",
+      "dev": true,
+      "dependencies": {
+        "@voxpelli/type-helpers": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@vscode/emmet-helper": {
@@ -5802,6 +5861,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "devOptional": true
+    },
+    "node_modules/buffered-async-iterable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/buffered-async-iterable/-/buffered-async-iterable-0.3.0.tgz",
+      "integrity": "sha512-McUDFN18nTngbI9EPqHXyifF3iReQtEeoCdukNtrypmPWMRxsJO6KbBihQ88PI+CIFhbCmm2cTkhgxmKADwFNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.6.0"
+      }
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -9191,6 +9259,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+      "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/individual": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
@@ -9488,6 +9568,54 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/installed-check": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/installed-check/-/installed-check-9.1.0.tgz",
+      "integrity": "sha512-L5kagD/v0B4yZGQNtIA0pjahXtoT8ehDol8gBOVQQgrApndC9qdksacQBeIxlXHVqSQsLWqMi91sq6/gunVCpg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "installed-check-core": "^8.2.1",
+        "meow": "^12.1.1",
+        "pony-cause": "^2.1.10",
+        "version-guard": "^1.1.1"
+      },
+      "bin": {
+        "installed-check": "cli-wrapper.cjs"
+      },
+      "engines": {
+        "node": ">=18.6.0"
+      }
+    },
+    "node_modules/installed-check-core": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/installed-check-core/-/installed-check-core-8.2.1.tgz",
+      "integrity": "sha512-kUkCgY0Y90lVLVmtWJx4SkC5SrOlMiEDmMDALRib14mlbqYefrG53xj0MyTJoAYD2dClX35MuqEs/KBBJGAHIg==",
+      "dev": true,
+      "dependencies": {
+        "@voxpelli/semver-set": "^5.0.2",
+        "@voxpelli/typed-utils": "^1.6.0",
+        "is-glob": "^4.0.3",
+        "list-installed": "^5.2.1",
+        "picomatch": "^4.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=18.6.0"
+      }
+    },
+    "node_modules/installed-check/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/internal-slot": {
@@ -10390,6 +10518,21 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/list-installed": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/list-installed/-/list-installed-5.2.2.tgz",
+      "integrity": "sha512-lmztqfWinwIiH19Rwwf4B1T9oFB0Kdfjf3nB3T88Ypln0n/tm5uJYK1rmg+/jZrctLwDQpRox/vGMNqqtkZWLg==",
+      "dev": true,
+      "dependencies": {
+        "buffered-async-iterable": "^0.3.0",
+        "pony-cause": "^2.1.10",
+        "read-pkg": "^9.0.1",
+        "read-workspaces": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.6.0"
+      }
+    },
     "node_modules/lite-youtube-embed": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.2.tgz",
@@ -11044,6 +11187,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
+    "node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -13202,6 +13357,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/pony-cause": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-2.1.10.tgz",
+      "integrity": "sha512-3IKLNXclQgkU++2fSi93sQ6BznFuxSLB11HdvZQ6JW/spahf/P1pAHBQEahr20rs0htZW0UDkM1HmA+nZkXKsw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.35",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
@@ -13694,6 +13858,69 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "index-to-position": "^0.1.2",
+        "type-fest": "^4.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-workspaces": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/read-workspaces/-/read-workspaces-1.1.1.tgz",
+      "integrity": "sha512-Ba9yKEuZLPsAx0vq9jnKQbMaQPZu4GnXLZOg5b4DehAdTZOPJ8NBlMaHpfVbyGX3ax/bIC+ci+nWjmbTRf9i2g==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/map-workspaces": "^3.0.4",
+        "@pnpm/workspace.read-manifest": "^1.0.3",
+        "read-pkg": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.6.0"
+      }
+    },
+    "node_modules/read-yaml-file": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-2.1.0.tgz",
+      "integrity": "sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^4.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10.13"
       }
     },
     "node_modules/readable-stream": {
@@ -17461,6 +17688,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/version-guard": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/version-guard/-/version-guard-1.1.1.tgz",
+      "integrity": "sha512-MGQLX89UxmYHgDvcXyjBI0cbmoW+t/dANDppNPrno64rYr8nH4SHSuElQuSYdXGEs0mUzdQe1BY+FhVPNsAmJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.48"
       }
     },
     "node_modules/version-selector-type": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,12 @@
     "watch": "npm run watch --workspace packages/knip",
     "docs": "npm run dev --workspace packages/docs",
     "format": "npm run format --workspaces --if-present",
-    "test": "npm run qa --workspaces --if-present"
+    "test": "npm run qa --workspaces --if-present && installed-check --no-include-workspace-root --ignore-dev"
   },
   "peerDependencies": {
     "knip": "file:packages/knip"
+  },
+  "devDependencies": {
+    "installed-check": "^9.1.0"
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,6 +10,9 @@
     "url": "github:webpro/knip",
     "directory": "packages/docs"
   },
+  "engines": {
+    "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+  },
   "scripts": {
     "prebuild": "tsx scripts/generate-plugin-docs.ts",
     "build": "astro check && astro build",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",
+  "engines": {
+    "node": "^18.18.0 || >=20.0.0"
+  },
   "dependencies": {
     "@eslint/js": "^8.57.0",
     "@typescript-eslint/eslint-plugin": "^7.5.0",


### PR DESCRIPTION
I used `knip` as a good project to verify the latest addition of workspace support in my [`installed-check`](https://github.com/voxpelli/node-installed-check) module, and I thought I could just as well send a PR in case you are interested in running it yourself.

It mainly verifies that one doesn't promise more in `engines.node` than what ones dependencies can back up, but it also has checks for whether one is running an outdated `node_modules` installation (as else the other data will be wrong as it uses the locally installed data for verification) and whether one promises a wider peer dependency range than what ones dependencies does (not applicable to this project)

Running it in verbose mode (`--verbose / -v`) shows that there are a couple of dependencies who are not publishing a node.js engine range:

```
@knip/docs: @astro-community/astro-embed-youtube: Missing "engines.node"
@knip/docs: @astrojs/starlight: Missing "engines.node"
knip: easy-table: Missing "engines.node"
knip: jiti: Missing "engines.node"
knip: js-yaml: Missing "engines.node"
knip: minimist: Missing "engines.node"
knip: picocolors: Missing "engines.node"
knip: resolve: Missing "engines.node"
knip: summary: Missing "engines.node"
knip: zod: Missing "engines.node"
```

But apart from those it verified that `knip` itself has a good engine range right now and it suggested engine ranges for the two other workspaces as well.

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
