### PR TITLE
Fix typos in docs

### DIFF
--- a/packages/docs/src/content/docs/explanations/plugins.md
+++ b/packages/docs/src/content/docs/explanations/plugins.md
@@ -42,7 +42,7 @@ In this case, the plugin will return the `eslint-config-airbnb`,
 Knip knows they should be listed in `package.json`.
 
 Some tools allow configuration to be stored in `package.json`, that's why some
-the relevant plugins contain `package.json` in the list of `config` files.
+of the relevant plugins contain `package.json` in the list of `config` files.
 
 :::tip[Summary]
 
@@ -69,7 +69,7 @@ configured.
 :::tip[Plugins result in less configuration]
 
 Plugins even consult the configuration files of these tools, in case alternative
-entry files should be used. So you need don't need to repeat this in your Knip
+entry files should be used. So you don't need to repeat this in your Knip
 configuration.
 
 :::

--- a/packages/docs/src/content/docs/explanations/why-use-knip.md
+++ b/packages/docs/src/content/docs/explanations/why-use-knip.md
@@ -52,7 +52,7 @@ synergy:
 - This approach is amplified in a monorepo setting. In fact, files and internal
   dependencies can recursively reference each other (across workspaces).
 
-The disadvantages of this strategy are not be dismissed: increased complexity
+The disadvantages of this strategy are not to be dismissed: increased complexity
 and less performance. In this early phase of the project completeness and
 correctness are valued over speed. Not in the least because the speed of
 automating this is still many times faster than the manual process. Both

--- a/packages/docs/src/content/docs/features/auto-fix.mdx
+++ b/packages/docs/src/content/docs/features/auto-fix.mdx
@@ -41,7 +41,7 @@ The `export` keyword for unused exports is removed:
 +class MyClass {}
 ```
 
-Note that also the `default` keyword was removed here.
+Also note that the `default` keyword was removed here.
 
 Knip cleans up the whole or part of re-exports:
 

--- a/packages/docs/src/content/docs/features/compilers.md
+++ b/packages/docs/src/content/docs/features/compilers.md
@@ -32,8 +32,8 @@ them however you like.
 ## Custom Compilers
 
 Additional custom compilers can be added, and built-in compilers can be
-overridden. Since compilers are functions, the Knip configuration file must to
-be a dynamic `.js` or `.ts` file.
+overridden. Since compilers are functions, the Knip configuration file must be a
+dynamic `.js` or `.ts` file.
 
 ### Interface
 

--- a/packages/docs/src/content/docs/features/reporters.md
+++ b/packages/docs/src/content/docs/features/reporters.md
@@ -78,9 +78,9 @@ knip --reporter json
 
 ### Markdown
 
-The built-in `markdown` reporter output is meant to be saved to a markdown file.
+The built-in `markdown` reporter output is meant to be saved to a Markdown file.
 This allows following the changes in issues over time. It reports issues in
-markdown tables separated by issue types as headings, for example:
+Markdown tables separated by issue types as headings, for example:
 
 ```md
 # Knip report

--- a/packages/docs/src/content/docs/guides/handling-issues.mdx
+++ b/packages/docs/src/content/docs/guides/handling-issues.mdx
@@ -11,7 +11,7 @@ positives, but also things that can actually be removed from the codebase. You
 can get a lot of value out of Knip, but sometimes it requires some initial
 configuration.
 
-This pages guides you in dealing with false positives. It makes sense to go over
+This page guides you in dealing with false positives. It makes sense to go over
 the issue types one by one. For instance, reducing the number of unused files
 will also reduce the number of unused dependencies. It's recommended to work
 this list from top to bottom.


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
I saw a few typos while browsing the docs, so here's some fixes for them :slightly_smiling_face: 