### PR TITLE
feat: support commitlint plugins key

### DIFF
--- a/packages/knip/fixtures/plugins/commitlint/.commitlintrc.json
+++ b/packages/knip/fixtures/plugins/commitlint/.commitlintrc.json
@@ -1,1 +1,1 @@
-{ "extends": ["@commitlint/config-conventional"] }
+{ "extends": ["@commitlint/config-conventional"], "plugins": ["commitlint-plugin-tense"] }

--- a/packages/knip/fixtures/plugins/commitlint/commitlint.config.js
+++ b/packages/knip/fixtures/plugins/commitlint/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = { extends: ['@commitlint/config-conventional'], plugins: ['commitlint-plugin-tense'] };

--- a/packages/knip/fixtures/plugins/commitlint/package.json
+++ b/packages/knip/fixtures/plugins/commitlint/package.json
@@ -6,6 +6,7 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "plugins": ["commitlint-plugin-tense"]
   }
 }

--- a/packages/knip/src/plugins/commitlint/index.ts
+++ b/packages/knip/src/plugins/commitlint/index.ts
@@ -6,6 +6,7 @@ import type { Plugin, ResolveConfig, IsPluginEnabled } from '#p/types/plugins.js
 
 type CommitLintConfig = {
   extends: string[];
+  plugins: string[];
 };
 
 const title = 'commitlint';
@@ -22,7 +23,9 @@ const config = [
 ];
 
 const resolveConfig: ResolveConfig<CommitLintConfig> = config => {
-  return config.extends ? [config.extends].flat() : [];
+  const extendsConfigs = config.extends ? [config.extends].flat() : [];
+  const plugins = config.plugins ? [config.plugins].flat() : [];
+  return [...extendsConfigs, ...plugins];
 };
 
 export default {

--- a/packages/knip/test/plugins/commitlint.test.ts
+++ b/packages/knip/test/plugins/commitlint.test.ts
@@ -16,11 +16,14 @@ test('Find dependencies with the Commitizen plugin', async () => {
   assert(issues.unlisted['.commitlintrc.json']['@commitlint/config-conventional']);
   assert(issues.unlisted['commitlint.config.js']['@commitlint/config-conventional']);
   assert(issues.unlisted['package.json']['@commitlint/config-conventional']);
+  assert(issues.unlisted['.commitlintrc.json']['commitlint-plugin-tense']);
+  assert(issues.unlisted['commitlint.config.js']['commitlint-plugin-tense']);
+  assert(issues.unlisted['package.json']['commitlint-plugin-tense']);
 
   assert.deepEqual(counters, {
     ...baseCounters,
     devDependencies: 1,
-    unlisted: 3,
+    unlisted: 6,
     processed: 1,
     total: 1,
   });


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
Currently, knip only supports commitlint extends, but [not plugins](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/types/src/load.ts#L30). This pr aims to fix that