### PR TITLE
feat: support all vitest built in reporters

### DIFF
--- a/packages/knip/fixtures/plugins/vitest3/vitest.config.ts
+++ b/packages/knip/fixtures/plugins/vitest3/vitest.config.ts
@@ -10,6 +10,18 @@ export default defineConfig(configEnv =>
         globals: true,
         include: ['**/*.test.{ts,tsx}'],
         setupFiles: ['./src/setupTests.tsx'],
+        reporters: [
+          'basic',
+          'verbose',
+          'dot',
+          'junit',
+          'json',
+          'html',
+          'tap',
+          'tap-flat',
+          'hanging-process',
+          'github-actions',
+        ],
         mockReset: true,
         coverage: {
           provider: 'v8',

--- a/packages/knip/src/plugins/vitest/helpers.ts
+++ b/packages/knip/src/plugins/vitest/helpers.ts
@@ -26,7 +26,20 @@ export const getEnvPackageName = (env: string) => {
   return `vitest-environment-${env}`;
 };
 
-const builtInReporters = ['default', 'verbose', 'dot', 'json', 'tap', 'tap-flat', 'junit', 'hanging-process'];
+// See full list here : https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/node/reporters/index.ts#L30
+const builtInReporters = [
+  'basic',
+  'default',
+  'dot',
+  'github-actions',
+  'hanging-process',
+  'html',
+  'json',
+  'junit',
+  'tap',
+  'tap-flat',
+  'verbose',
+];
 
 export const getExternalReporters = (reporters?: ViteConfig['test']['reporters']) =>
   reporters


### PR DESCRIPTION
<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
Previously, knip reported build in reporters (such as `basic`) as third parties librarires. This pr aims to resolve this