### PR TITLE
fix(plugin/babel): bypass directly required plugins or presets in babel config

### DIFF
--- a/packages/knip/fixtures/plugins/babel/.babelrc.js
+++ b/packages/knip/fixtures/plugins/babel/.babelrc.js
@@ -37,6 +37,8 @@ const config = {
         },
       },
     ],
+    // Simulates a required plugin, should not be added to the unspecified plugins array
+    function myCustomPlugin() {}
   ],
 };
 

--- a/packages/knip/src/plugins/babel/index.ts
+++ b/packages/knip/src/plugins/babel/index.ts
@@ -16,7 +16,7 @@ const isEnabled: IsPluginEnabled = ({ dependencies }) => hasDependency(dependenc
 const config = ['babel.config.{json,js,cjs,mjs,cts}', '.babelrc.{json,js,cjs,mjs,cts}', '.babelrc', 'package.json'];
 
 const getName = (value: string | [string, unknown]) =>
-  typeof value === 'string' ? [value] : Array.isArray(value) ? [value[0]] : [];
+  [Array.isArray(value) ? value[0] : value].filter(name => typeof name === 'string');
 
 export const getDependenciesFromConfig = (config: BabelConfigObj): string[] => {
   const presets = config.presets?.flatMap(getName).map(name => resolveName(name, 'preset')) ?? [];


### PR DESCRIPTION
Babel supports importing or directly declaring plugins in the JS configuration. Currently `knip` will throw an error trying to parse the plugin name if a plugin/preset is directly imported.

Example config directly from babel monorepo: https://github.com/babel/babel/blob/main/babel.config.js#L199

I'm not sure if `knip` will actually handle the `require`/`import` in JS babel configs yet, but this at least makes it not throw.