### PR TITLE
fix: next route handler extensions

### DIFF
--- a/packages/knip/src/plugins/next/index.ts
+++ b/packages/knip/src/plugins/next/index.ts
@@ -15,7 +15,7 @@ const productionEntryFilePatternsWithoutSrc = [
   '{instrumentation,middleware}.{js,ts}',
   'app/global-error.{js,jsx,ts,tsx}',
   'app/**/{error,layout,loading,not-found,page,template,default}.{js,jsx,ts,tsx}',
-  'app/**/route.{js,ts}',
+  'app/**/route.{js,jsx,ts,tsx}',
   'app/{manifest,sitemap,robots}.{js,ts}',
   'app/**/{icon,apple-icon}.{js,jsx,ts,tsx}',
   'app/**/{opengraph,twitter}-image.{js,jsx,ts,tsx}',


### PR DESCRIPTION
This is unfortunately undocumented like most next.js quirks but this does work if you are making an og image route handler kinda like the `opengraph-image` convention but with less magic