### PR TITLE
Fix module resolution across multiple dependent workspaces with incompatible tsconfigs 

### DIFF
--- a/packages/knip/fixtures/workspaces-complex-module-resolution/node_modules/@monorepo/workspaceA
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/node_modules/@monorepo/workspaceA
@@ -1,0 +1,1 @@
+../../packages/workspaceA

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/node_modules/@monorepo/workspaceB
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/node_modules/@monorepo/workspaceB
@@ -1,0 +1,1 @@
+../../packages/workspaceB

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/package.json
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixtures/module-resolution-workspaces",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceA/package.json
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceA/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@monorepo/workspaceA",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@monorepo/workspaceB": "*"
+  }
+}

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceA/src/index.ts
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceA/src/index.ts
@@ -1,0 +1,3 @@
+import { usedFunction } from '@monorepo/workspaceB';
+
+usedFunction;

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceA/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceA/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "baseUrl": "src",
+    "declaration": true,
+    "paths": {
+      "#dummy": ["src"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist/**/*"]
+}

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/package.json
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@monorepo/workspaceB",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/src/exports.ts
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/src/exports.ts
@@ -1,0 +1,1 @@
+export const someFunction = () => 'bar';

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/src/index.ts
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/src/index.ts
@@ -1,0 +1,2 @@
+export * from 'exports';
+export { usedFunction } from 'used-fn';

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/src/used-fn.ts
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/src/used-fn.ts
@@ -1,0 +1,6 @@
+import { someFunction } from 'exports';
+
+export const usedFunction = () => {
+  someFunction();
+  return 'bar';
+};

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/packages/workspaceB/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "baseUrl": "src",
+    "declaration": true,
+    "paths": {
+      "#dummy-shared": ["src"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist/**/*"]
+}

--- a/packages/knip/fixtures/workspaces-complex-module-resolution/tsconfig.json
+++ b/packages/knip/fixtures/workspaces-complex-module-resolution/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "files": [],
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "references": [
+    { "path": "packages/workspaceA" },
+    { "path": "packages/workspaceB" },
+  ]
+}

--- a/packages/knip/src/index.ts
+++ b/packages/knip/src/index.ts
@@ -377,7 +377,11 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
   }
 
   // Delete principals including TS programs for GC, except when we still need its `LS.findReferences`
-  if (isSkipLibs && !isWatch) principals.forEach(principal => factory.deletePrincipal(principal));
+  if (isSkipLibs && !isWatch) {
+    for (const principal of principals) {
+      factory.deletePrincipal(principal);
+    }
+  }
 
   const isIdentifierReferenced = getIsIdentifierReferencedHandler(serializableMap);
 

--- a/packages/knip/src/index.ts
+++ b/packages/knip/src/index.ts
@@ -291,9 +291,18 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
     }
   };
 
-  const analyzeSourceFile = (filePath: string, principal: ProjectPrincipal) => {
+  const analyzeSourceFile = (filePath: string | undefined, principal?: ProjectPrincipal | undefined) => {
+    if (!filePath || analyzedFiles.has(filePath)) {
+      return;
+    }
+
     const workspace = chief.findWorkspaceByFilePath(filePath);
-    if (workspace) {
+    principal = principal || !workspace ? principal : factory.getPrincipalByPackageName(workspace.pkgName);
+
+    if (workspace && principal) {
+      // Add to analyzed files early to prevent risk of infinite recursion
+      analyzedFiles.add(filePath);
+
       const { imports, exports, scripts } = principal.analyzeSourceFile(filePath, {
         skipTypeOnly: isStrict,
         isFixExports: fixer.isEnabled && fixer.isFixUnusedExports,
@@ -319,11 +328,9 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
         const specifiers = _getDependenciesFromScripts(scripts, { cwd, manifestScriptNames, dependencies });
         for (const specifier of specifiers) {
           const specifierFilePath = handleReferencedDependency(specifier, filePath, workspace);
-          if (specifierFilePath) internalWorkspaceFilePaths.add(specifierFilePath);
+          analyzeSourceFile(specifierFilePath, principal);
         }
       }
-
-      analyzedFiles.add(filePath);
     }
   };
 
@@ -358,20 +365,19 @@ export const main = async (unresolvedConfiguration: CommandLineOptions) => {
       }
     } while (size !== principal.entryPaths.size);
 
-    for (const specifierFilePath of internalWorkspaceFilePaths) {
-      if (!analyzedFiles.has(specifierFilePath)) {
-        analyzeSourceFile(specifierFilePath, principal);
-      }
-    }
-
     for (const filePath of principal.getUnreferencedFiles()) unreferencedFiles.add(filePath);
     for (const filePath of principal.entryPaths) entryPaths.add(filePath);
 
     principal.reconcileCache(serializableMap);
-
-    // Delete principals including TS programs for GC, except when we still need its `LS.findReferences`
-    if (isSkipLibs && !isWatch) factory.deletePrincipal(principal);
   }
+
+  // Re-analyze files from local workspaces that were referenced, but have not yet been successfully resolved
+  for (const specifierFilePath of internalWorkspaceFilePaths) {
+    analyzeSourceFile(specifierFilePath);
+  }
+
+  // Delete principals including TS programs for GC, except when we still need its `LS.findReferences`
+  if (isSkipLibs && !isWatch) principals.forEach(principal => factory.deletePrincipal(principal));
 
   const isIdentifierReferenced = getIsIdentifierReferencedHandler(serializableMap);
 

--- a/packages/knip/src/typescript/resolveModuleNames.ts
+++ b/packages/knip/src/typescript/resolveModuleNames.ts
@@ -38,7 +38,10 @@ export function createCustomModuleResolver(
         : `${containingFile}:${moduleName}`;
       if (resolutionCache.has(key)) return resolutionCache.get(key);
       const resolvedModule = resolveModuleName(moduleName, containingFile);
-      resolutionCache.set(key, resolvedModule);
+      // Don't save resolution misses, because it might be resolved later under a different principal
+      if (resolvedModule) {
+        resolutionCache.set(key, resolvedModule);
+      }
       return resolvedModule;
     });
   }

--- a/packages/knip/test/workspaces-complex-module-resolution.test.ts
+++ b/packages/knip/test/workspaces-complex-module-resolution.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../src/index.js';
+import { resolve } from '../src/util/path.js';
+import baseArguments from './helpers/baseArguments.js';
+import baseCounters from './helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/workspaces-complex-module-resolution');
+
+test('Resolve modules properly across multiple workspaces', async () => {
+  const { counters } = await main({
+    ...baseArguments,
+    cwd,
+    isDebug: true,
+  });
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    processed: 5,
+    total: 5,
+  });
+});

--- a/packages/knip/test/workspaces-complex-module-resolution.test.ts
+++ b/packages/knip/test/workspaces-complex-module-resolution.test.ts
@@ -16,7 +16,7 @@ test('Resolve modules properly across multiple workspaces', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    processed: 5,
-    total: 5,
+    processed: 4,
+    total: 4,
   });
 });


### PR DESCRIPTION
Still draft until I can figure out why some tests are failing on github but not local.
 
This PR is my attempt to fix #610.

- Do not save module resolution failures in the `resolutionCache` of `resolveModuleNames.ts` so that a failed attempt to resolve a file in the wrong principal doesn't block resolution in the right principal from succeeding
- Analyze scripts rescursively in main analysis loop so they can be handled within the principal they belong to and don't get mixed up with the `internalWorkspaceFilePaths`
- Analyze all `internalWorkspaceFilePaths` after analyzing all of the principals and lookup which principal each belongs to
- Small adjustments to the way analyzed files are excluded from repeat processing to simplify code changes above