### PR TITLE
feat(plugins): add plugin for xo config

### DIFF
--- a/packages/knip/fixtures/plugins/xo/.xo-config.js
+++ b/packages/knip/fixtures/plugins/xo/.xo-config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  space: true,
+  prettier: true,
+  plugins: ['unused-imports'],
+  parserOptions: {emitDecoratorMetadata: true},
+  rules: {
+    'func-names': ['error', 'always'],
+  },
+};

--- a/packages/knip/fixtures/plugins/xo/node_modules/xo/package.json
+++ b/packages/knip/fixtures/plugins/xo/node_modules/xo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "xo",
+  "bin": "index.js"
+}

--- a/packages/knip/fixtures/plugins/xo/package.json
+++ b/packages/knip/fixtures/plugins/xo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fixtures/xo",
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo"
   },
   "devDependencies": {
     "xo": "^0.24.0"

--- a/packages/knip/fixtures/plugins/xo/package.json
+++ b/packages/knip/fixtures/plugins/xo/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@fixtures/xo",
+  "scripts": {
+    "test": "xo && ava"
+  },
+  "devDependencies": {
+    "xo": "^0.24.0"
+  },
+  "xo": {
+    "space": true,
+    "plugins": ["eslint-comments"]
+  }
+}

--- a/packages/knip/fixtures/plugins/xo/xo-config.cjs
+++ b/packages/knip/fixtures/plugins/xo/xo-config.cjs
@@ -1,0 +1,8 @@
+const mySharedConfig = require('glob');
+
+module.exports = {
+  ...mySharedConfig,
+  rules: {
+    'func-names': 'off',
+  },
+};

--- a/packages/knip/schema.json
+++ b/packages/knip/schema.json
@@ -507,6 +507,10 @@
           "title": "wrangler plugin configuration (https://github.com/webpro/knip/blob/main/src/plugins/wrangler/README.md)",
           "$ref": "#/definitions/plugin"
         },
+        "xo": {
+          "title": "xo plugin configuration (https://github.com/webpro/knip/blob/main/src/plugins/xo/README.md)",
+          "$ref": "#/definitions/plugin"
+        },
         "yorkie": {
           "title": "yorkie plugin configuration (https://github.com/webpro/knip/blob/main/src/plugins/yorkie/README.md)",
           "$ref": "#/definitions/plugin"

--- a/packages/knip/src/ConfigurationValidator.ts
+++ b/packages/knip/src/ConfigurationValidator.ts
@@ -135,6 +135,7 @@ const pluginsSchema = z.object({
   webpack: pluginSchema,
   wireit: pluginSchema,
   wrangler: pluginSchema,
+  xo: pluginSchema,
   yorkie: pluginSchema,
 });
 

--- a/packages/knip/src/plugins/index.ts
+++ b/packages/knip/src/plugins/index.ts
@@ -58,3 +58,4 @@ export { default as webpack } from './webpack/index.js';
 export { default as wireit } from './wireit/index.js';
 export { default as wrangler } from './wrangler/index.js';
 export { default as yorkie } from './yorkie/index.js';
+export { default as xo } from './xo/index.js';

--- a/packages/knip/src/plugins/xo/index.ts
+++ b/packages/knip/src/plugins/xo/index.ts
@@ -1,0 +1,34 @@
+import type { EnablerPatterns } from '#p/types/config.js';
+import type { IsPluginEnabled, Plugin, ResolveConfig } from '#p/types/plugins.js';
+import { hasDependency } from '#p/util/plugin.js';
+import { getDependenciesDeep } from '../eslint/helpers.js';
+import type { XOConfig } from './types.js';
+
+// link to xo docs: https://github.com/xojs/xo#config
+
+const title = 'xo';
+
+const enablers: EnablerPatterns = ['xo'];
+
+const isEnabled: IsPluginEnabled = ({ dependencies, config }) =>
+  hasDependency(dependencies, enablers) || 'xo' in config;
+
+const packageJsonPath = 'xo';
+const config: string[] = ['{.,}xo-config.{js,cjs,json,}', 'package.json'];
+
+const entry: string[] = ['{.,}xo-config.{js,cjs}'];
+
+const resolveConfig: ResolveConfig<XOConfig> = async (config, options) => {
+  const dependencies = await getDependenciesDeep(config, options);
+  return [...dependencies];
+};
+
+export default {
+  title,
+  enablers,
+  isEnabled,
+  packageJsonPath,
+  entry,
+  config,
+  resolveConfig,
+} satisfies Plugin;

--- a/packages/knip/src/plugins/xo/types.ts
+++ b/packages/knip/src/plugins/xo/types.ts
@@ -1,0 +1,13 @@
+import type { ESLintConfig } from '../eslint/types.js';
+
+export type XOConfig = ESLintConfig & {
+  envs?: string[] | undefined;
+  globals?: string[] | undefined;
+  ignores?: string[] | undefined;
+  nodeVersion?: string | boolean | undefined;
+  prettier?: boolean | undefined;
+  printConfig?: string | undefined;
+  semicolon?: boolean | undefined;
+  space?: boolean | number | undefined;
+  webpack?: boolean | object | undefined;
+};

--- a/packages/knip/test/plugins/xo.test.ts
+++ b/packages/knip/test/plugins/xo.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { main } from '../../src/index.js';
+import { resolve } from '../../src/util/path.js';
+import baseArguments from '../helpers/baseArguments.js';
+import baseCounters from '../helpers/baseCounters.js';
+
+const cwd = resolve('fixtures/plugins/xo');
+
+test('Find dependencies with the xo plugin', async () => {
+  const { issues, counters } = await main({
+    ...baseArguments,
+    cwd,
+  });
+
+  assert(issues.unlisted['.xo-config.js']['eslint-plugin-unused-imports']);
+  assert(issues.unlisted['xo-config.cjs']['glob']);
+  assert(issues.unlisted['package.json']['eslint-plugin-eslint-comments']);
+
+  assert.deepEqual(counters, {
+    ...baseCounters,
+    devDependencies: 1,
+    processed: 2,
+    unlisted: 3,
+    total: 2,
+  });
+});

--- a/packages/knip/test/plugins/xo.test.ts
+++ b/packages/knip/test/plugins/xo.test.ts
@@ -19,7 +19,6 @@ test('Find dependencies with the xo plugin', async () => {
 
   assert.deepEqual(counters, {
     ...baseCounters,
-    devDependencies: 1,
     processed: 2,
     unlisted: 3,
     total: 2,


### PR DESCRIPTION
Adds a plugin for [xo](https://github.com/xojs/xo#config). Essentially its an opinionated wrapper around eslint with a bunch of bundled rules and plugins, and the config object is just the eslint config object with some extra options. So to keep it consistent with the eslint plugin and avoid duplication I've just used the eslint helper to parse out any additional eslint plugins that have been added in the xo config.

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
