### PR TITLE
fix(plugin-commitlint): handling of `parserPreset` when it's not a string

### DIFF
--- a/packages/knip/fixtures/plugins/commitlint/.commitlintrc.json
+++ b/packages/knip/fixtures/plugins/commitlint/.commitlintrc.json
@@ -1,4 +1,5 @@
 {
   "extends": ["@commitlint/config-conventional"],
-  "plugins": ["commitlint-plugin-tense"]
+  "plugins": ["commitlint-plugin-tense"],
+  "parserPreset": "conventional-changelog-atom"
 }

--- a/packages/knip/fixtures/plugins/commitlint/commitlint.config.js
+++ b/packages/knip/fixtures/plugins/commitlint/commitlint.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   extends: ['lerna', '@commitlint/config-conventional'],
-  parserPreset: 'conventional-changelog-atom',
+  parserPreset: {
+    parserOpts: {
+      headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/u,
+    },
+  },
   formatter: '@commitlint/format',
   plugins: [
     {

--- a/packages/knip/src/plugins/commitlint/index.ts
+++ b/packages/knip/src/plugins/commitlint/index.ts
@@ -18,7 +18,7 @@ const config = [
   'package.json',
 ];
 
-const resolveConfig: ResolveConfig<CommitLintConfig> = config => {
+const resolveConfig: ResolveConfig<CommitLintConfig> = async config => {
   const extendsConfigs = config.extends
     ? [config.extends]
         .flat()
@@ -26,8 +26,15 @@ const resolveConfig: ResolveConfig<CommitLintConfig> = config => {
     : [];
   const plugins = config.plugins ? [config.plugins].flat().filter(s => typeof s === 'string') : [];
   const formatter = config.formatter ? [config.formatter] : [];
-  const parserPreset = config.parserPreset ? [config.parserPreset] : [];
-  return [...extendsConfigs, ...plugins, ...formatter, ...parserPreset];
+  const parserPreset = await config.parserPreset;
+  const parserPresetPaths: string[] = parserPreset
+    ? typeof parserPreset === 'string'
+      ? [parserPreset]
+      : parserPreset.path
+        ? [parserPreset.path ?? parserPreset]
+        : []
+    : [];
+  return [...extendsConfigs, ...plugins, ...formatter, ...parserPresetPaths];
 };
 
 export default {

--- a/packages/knip/src/plugins/commitlint/types.ts
+++ b/packages/knip/src/plugins/commitlint/types.ts
@@ -2,5 +2,11 @@ export type CommitLintConfig = {
   extends?: string | string[];
   plugins?: string[];
   formatter?: string;
-  parserPreset?: string;
+  parserPreset?: string | ParserPreset | Promise<ParserPreset>;
+};
+
+type ParserPreset = {
+  name?: string;
+  path?: string;
+  parserOpts?: unknown;
 };

--- a/packages/knip/test/plugins/commitlint.test.ts
+++ b/packages/knip/test/plugins/commitlint.test.ts
@@ -15,11 +15,11 @@ test('Find dependencies with the Commitizen plugin', async () => {
 
   assert(issues.unlisted['.commitlintrc.json']['@commitlint/config-conventional']);
   assert(issues.unlisted['.commitlintrc.json']['commitlint-plugin-tense']);
+  assert(issues.unlisted['.commitlintrc.json']['conventional-changelog-atom']);
 
   assert(issues.unlisted['commitlint.config.js']['@commitlint/config-conventional']);
   assert(issues.unlisted['commitlint.config.js']['commitlint-plugin-tense']);
   assert(issues.unlisted['commitlint.config.js']['commitlint-config-lerna']);
-  assert(issues.unlisted['commitlint.config.js']['conventional-changelog-atom']);
   assert(issues.unlisted['commitlint.config.js']['@commitlint/format']);
 
   assert(issues.unlisted['package.json']['@commitlint/config-conventional']);


### PR DESCRIPTION
fix #631

<!--

- Try to author code and/or docs similar to the rest of the repository
- Run `npm run format` (from root)
- Run `npm test` (from root)

Through [the CI workflow][1] the changes will be tested in Ubuntu, macOS and Windows. The changes will also be [tested
against a number of external projects][2].

[1]: https://github.com/webpro/knip/blob/main/.github/workflows/test.yml
[2]: https://github.com/webpro/knip/blob/main/.github/workflows/integration.yml

-->
